### PR TITLE
Safari requires position: relative; to be set when applying overflow-x hidden

### DIFF
--- a/site/layout/style.css
+++ b/site/layout/style.css
@@ -7,5 +7,4 @@
 html, body {
   overflow-x: hidden;
   position: relative;
-  background: white;
 }

--- a/site/layout/style.css
+++ b/site/layout/style.css
@@ -7,4 +7,5 @@
 html, body {
   overflow-x: hidden;
   position: relative;
+  background: white;
 }

--- a/site/layout/style.css
+++ b/site/layout/style.css
@@ -4,6 +4,7 @@
   box-sizing: border-box;
 }
 
-body {
+html, body {
   overflow-x: hidden;
+  position: relative;
 }


### PR DESCRIPTION
### Motivation
#50 , #35
It was also happening in safari on OSX

[fix credit](http://www.tonylea.com/2010/safari-overflow-hidden-problem/)

### Test plan
- View in safari on iOS devices.
- on iPhone 5S and 7 in particular

### Pre-flight checklist
- n/a Unit tests
- n/a Has been design reviewed
- `¯\_(ツ)_/¯` Add a gif