### PR TITLE
Fix for #34 iOS thinking our registration number is a phone number

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimal-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
+    <meta name="format-detection" content="telephone=no">
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css" />
     <title>Red Badger</title>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>


### PR DESCRIPTION
![giphy 1](https://cloud.githubusercontent.com/assets/487468/19274950/e7d68048-8fc9-11e6-98e2-8906bedbfe2d.gif)

### Motivation

Fixing #34 

### Test plan

- On iOS device check that company registration numbers are not recognised as phone numbers anymore

### Pre-merge checklist

- [x] Unit tests - N/A
- [x] Reviews
  - [x] Code review
  - [x] Design review - N/A
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
- [ ] Tester approved

Preview App: http://rb-website-honestly--staging.s3-website-eu-west-1.amazonaws.com/eae4891/