### PR TITLE
Tweak: Remove extra spacing on tech slice button

### DIFF
--- a/site/pages/home/index.js
+++ b/site/pages/home/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import TopSlice from './homepage-top-slice';
-import Brie from './brie-slice';
-import BlogSlice from './blog-slice';
 import CaseStudy from '../../components/case-study';
 import TechSlice from './tech-slice';
+import Brie from './brie-slice';
+import BlogSlice from './blog-slice';
 
 export default function HomePage() {
   return (

--- a/site/pages/home/tech-slice/styles.css
+++ b/site/pages/home/tech-slice/styles.css
@@ -11,7 +11,7 @@
   composes: dividerBlack from "../../../css/_divider.css";
   color: white;
   background-color: black;
-  padding: 30px 20px 70px 20px;
+  padding: 30px 20px 40px 20px;
   text-align: center;
 }
 
@@ -90,7 +90,7 @@
 
   .moreBtn {
     composes: primaryButton from "../../../css/_links.css";
-    margin: 60px 0;
+    margin: 60px 0 0 0;
   }
 }
 


### PR DESCRIPTION
### Motivation

Slight error on the tech slice- the button has too much space below it.

### Test plan

- The button has 60px below it, as per the design.

### Pre-merge checklist

- [ ] ~~Unit tests~~
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] ~~Manual testing~~
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [x] Tester approved

