### PR TITLE
Auto deploy of master onto staging

### DIFF
--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -24,9 +24,24 @@ createCommitSite() {
   echo Done!
 }
 
+masterToStaging() {
+  echo Deploying current master to staging
+  source bin/load-env.sh
+  make clean
+  make build
+  echo Copying assets to S3
+  aws s3 sync ./dist/assets s3://$BUCKET_NAME/assets
+  make services-deploy
+  make publish-service-invoke
+  echo Done!
+}
+
 case "$1" in
   create-commit-site)
     createCommitSite
+    ;;
+  master-to-staging)
+    masterToStaging
     ;;
   *)
     echo "Eh? Unknown command '$1'"

--- a/circle.yml
+++ b/circle.yml
@@ -19,3 +19,7 @@ deployment:
     branch: /.*/
     commands:
       - ./bin/ci-deploy.sh create-commit-site
+  staging:
+    branch: master
+    commands:
+      - ./bin/ci-deploy.sh master-to-staging


### PR DESCRIPTION
![giphy 2](https://cloud.githubusercontent.com/assets/487468/19314724/1721efe4-9093-11e6-9efc-5f87eb0a3344.gif)

### Motivation

Currently we're only having preview apps but no traditional staging environment for the latest master. This PR will enable CircleCI to deploy latest master branch to staging env every time there is an update available on `master`.

### Test plan

- Push something to master
- Check that it is deployed to staging and available on http://rb-website-honestly--staging.s3-website-eu-west-1.amazonaws.com/

### Pre-merge checklist

- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review - N/A
- [ ] Manual testing - N/A
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved - N/A
