### PR TITLE
Added footer and header links. Fixed maximum width on footer

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -15,6 +15,7 @@ export function makeApp({ element, data, history }) {
 
   routes.forEach(route => {
     const render = () => {
+      window.scrollTo(0, 0);
       const Component = route.component;
       ReactDOM.render(<Component />, element);
     };

--- a/site/components/case-study/index.js
+++ b/site/components/case-study/index.js
@@ -53,7 +53,7 @@ const CaseStudy = () => (
         </a>
         <a href="https://red-badger.com/our-work/case-study/sky-cms/" className={styles.caseText}>
           <span>
-            Drop in customers pushing the 'need more help' button
+            Drop in customers pushing the &lsquo;need more help&rsquo; button
           </span>
         </a>
         <a href="https://red-badger.com/our-work/case-study/sky-cms/">

--- a/site/components/case-study/index.js
+++ b/site/components/case-study/index.js
@@ -25,21 +25,39 @@ const CaseStudy = () => (
     <h2 className={styles.heading}>We solve complex problems and deliver real impact.</h2>
     <div className={styles.figuresContainer}>
       <div>
-        <InlineSVG src={fortnumFigureSVG} className={styles.caseFigure} alt="Three" />
-        <span className={styles.caseText}>Number of awards for the new online store</span>
-        <img alt="The logo of Fortnum & Masons" src={fortnumPNG} />
+        <a href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
+          <InlineSVG src={fortnumFigureSVG} className={styles.caseFigure} alt="Three" />
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/fortnum-and-mason/" className={styles.caseText}>
+          <span>Number of awards for the new online store</span>
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
+          <img alt="The logo of Fortnum & Masons" src={fortnumPNG} />
+        </a>
       </div>
       <div>
-        <InlineSVG src={camdenFigureSVG} className={styles.caseFigure} alt="Ten" />
-        <span className={styles.caseText}>Weeks to deliver a new online platform</span>
-        <img alt="The logo of Camden Market" src={camdenPNG} />
+        <a href="https://red-badger.com/our-work/case-study/camden-market/">
+          <InlineSVG src={camdenFigureSVG} className={styles.caseFigure} alt="Ten" />
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/camden-market/" className={styles.caseText}>
+          <span>Weeks to deliver a new online platform</span>
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/camden-market/">
+          <img alt="The logo of Camden Market" src={camdenPNG} />
+        </a>
       </div>
       <div>
-        <InlineSVG src={skyFigureSVG} className={styles.caseFigure} alt="50%" />
-        <span className={styles.caseText}>
-          Drop in customers pushing the 'need more help' button
-        </span>
-        <img alt="The logo of Sky" src={skyPNG} />
+        <a href="https://red-badger.com/our-work/case-study/sky-cms/">
+          <InlineSVG src={skyFigureSVG} className={styles.caseFigure} alt="50%" />
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/sky-cms/" className={styles.caseText}>
+          <span>
+            Drop in customers pushing the 'need more help' button
+          </span>
+        </a>
+        <a href="https://red-badger.com/our-work/case-study/sky-cms/">
+          <img alt="The logo of Sky" src={skyPNG} />
+        </a>
       </div>
       <div>
         <InlineSVG src={tescoFigureSVG} className={styles.caseFigure} alt="54%" />

--- a/site/components/case-study/index.js
+++ b/site/components/case-study/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import InlineSVG from 'svg-inline-react';
 import styles from './style.css';
+import Link from '../link';
 
 /* PNG logo imports */
 import bbcPNG from './PNG/bbc.png';
@@ -76,7 +77,7 @@ const CaseStudy = () => (
       <img alt="The logo of Car Trawler" src={cartrawlerPNG} />
     </div>
     <div className={styles.buttonContainer}>
-      <a className={styles.button} href="/case-studies">See more of our work</a>
+      <Link className={styles.button} to="caseStudiesPage">See more of our work</Link>
     </div>
   </section>
 );

--- a/site/components/case-study/index.js
+++ b/site/components/case-study/index.js
@@ -76,7 +76,7 @@ const CaseStudy = () => (
       <img alt="The logo of Car Trawler" src={cartrawlerPNG} />
     </div>
     <div className={styles.buttonContainer}>
-      <a className={styles.button} href="https://red-badger.com/our-work/">See more of our work</a>
+      <a className={styles.button} href="/case-studies">See more of our work</a>
     </div>
   </section>
 );

--- a/site/components/case-study/style.css
+++ b/site/components/case-study/style.css
@@ -14,13 +14,17 @@
 .caseStudyContainer {
   composes: dividerBlack from "../../css/_divider.css";
   background-color: black;
-  padding: 0px 5% 12px 5%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 }
 
 .figuresContainer {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  max-width: 1440px;
 }
 
 .figuresContainer div {
@@ -60,6 +64,8 @@
   border-top: 1px solid linesOnBlack;
   border-bottom: 1px solid linesOnBlack;
   padding: 30px;
+  max-width: 1440px;
+  width: 100%;
 }
 
 .caseCompanies img {

--- a/site/components/case-study/style.css
+++ b/site/components/case-study/style.css
@@ -50,7 +50,7 @@
   composes: serif from "../../css/typography/_fonts.css";
   color: white;
   text-align: center;
-  padding: 30px;
+  padding: 30px 0px;
   max-width: 100%;
 }
 
@@ -88,7 +88,9 @@
   .heading {
     padding: 40px;
   }
-
+  .caseText {
+    padding: 30px;
+  }
   .figuresContainer div {
     width: 49%;
     padding: 60px 0px;
@@ -100,8 +102,6 @@
 
   .caseCompanies {
     justify-content: space-between;
-    padding-left: 0px;
-    padding-right: 0px;
   }
 
   .caseCompanies img:first-child {

--- a/site/components/footer/index.js
+++ b/site/components/footer/index.js
@@ -1,5 +1,5 @@
-import classnames from 'classnames/bind';
 import InlineSVG from 'svg-inline-react';
+import classnames from 'classnames/bind';
 import React from 'react';
 import styles from './style.css';
 
@@ -35,7 +35,7 @@ const Footer = () => (
               <a href="https://red-badger.com/about-us/join-us/">What we do</a>
             </li>
             <li>
-              <a href="https://red-badger.com/blog/">Blog</a>
+              <a href="http://red-badger.com/blog/">Blog</a>
             </li>
             <li>
               <a href="https://red-badger.com/about-us/events/">Events</a>

--- a/site/components/footer/index.js
+++ b/site/components/footer/index.js
@@ -29,19 +29,19 @@ const Footer = () => (
               <a href="/">Home</a>
             </li>
             <li>
-              <a href="/about-us/">About us</a>
+              <a href="https://red-badger.com/about-us/">About us</a>
             </li>
             <li>
-              <a href="/about-us/join-us/">What we do</a>
+              <a href="https://red-badger.com/about-us/join-us/">What we do</a>
             </li>
             <li>
-              <a href="/blog/">Blog</a>
+              <a href="https://red-badger.com/blog/">Blog</a>
             </li>
             <li>
-              <a href="/about-us/events/">Events</a>
+              <a href="https://red-badger.com/about-us/events/">Events</a>
             </li>
             <li>
-              <a href="/about-us/join-us/">Jobs</a>
+              <a href="https://red-badger.com/about-us/join-us/">Jobs</a>
             </li>
           </ul>
         </nav>
@@ -149,8 +149,12 @@ const Footer = () => (
       </div>
       <div className={styles.footerEndContainer}>
         <div className={cx('section', 'disclaimer', 'noBorder')}>
-          <p className={cx('afterDivider', 'disclaimerParagraph')}>&copy; Red Badger Consultancy Ltd 2016</p>
-          <p className={cx('afterDivider', 'disclaimerParagraph')}>Registered number 345 678 912 UK</p>
+          <p className={cx('afterDivider', 'disclaimerParagraph')}>
+            &copy; Red Badger Consultancy Ltd 2016
+          </p>
+          <p className={cx('afterDivider', 'disclaimerParagraph')}>
+            Registered number 345 678 912 UK
+          </p>
           <p className={styles.disclaimerParagraph}>VAT Registration No. 990 8085 82</p>
           <p className={styles.cookieWarning}>
             We use cookies on our website. For more information, view our privacy policy.

--- a/site/components/footer/style.css
+++ b/site/components/footer/style.css
@@ -136,8 +136,14 @@
     display: block;
     overflow: hidden;
   }
+  .footer {
+    align-items: center;
+    justify-content: center;
+  }
   .badgerIcon {
-    margin-bottom: 16px;
+    position: absolute;
+    right: 15px;
+    bottom: 15px;
   }
 
   .address {
@@ -209,5 +215,8 @@
   .footerEndContainer {
     display: flex;
     justify-content: space-between;
+  }
+  .footerContainer {
+    position: relative;
   }
 }

--- a/site/components/footer/style.css
+++ b/site/components/footer/style.css
@@ -13,7 +13,8 @@
 }
 
 .footerContainer {
-  max-width: maxWidth;
+  max-width: 1440px;
+  width: 100%;
 }
 
 .nav {
@@ -175,7 +176,7 @@
 
   .footerSections {
     display: flex;
-    width: 85%;
+    width: 55%;
   }
 
   .disclaimer {
@@ -207,5 +208,6 @@
   }
   .footerEndContainer {
     display: flex;
+    justify-content: space-between;
   }
 }

--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -12,10 +12,10 @@ const Header = () => {
 
       <nav className={styles.mediumScreenNavContainer} role="navigation">
         <ul className={styles.mediumScreenNav}>
-          <li><a href="/services/">Services</a></li>
-          <li><a href="/about-us/">About us</a></li>
-          <li><a href="/blog/">Blog</a></li>
-          <li><a href="/about-us/events/">Events</a></li>
+          <li><a href="https://red-badger.com/services/">Services</a></li>
+          <li><a href="https://red-badger.com/about-us/">About us</a></li>
+          <li><a href="http://red-badger.com/blog/">Blog</a></li>
+          <li><a href="https://red-badger.com/about-us/events/">Events</a></li>
         </ul>
       </nav>
 
@@ -31,12 +31,12 @@ const Header = () => {
           <nav className={styles.smallScreenNavContainer} role="navigation">
             <ul className={styles.smallScreenNav}>
               <li><a href="/">Home</a></li>
-              <li><a href="/about-us/">About us</a></li>
-              <li><a href="/services/">Services</a></li>
-              <li><a href="/blog/">Blog</a></li>
-              <li><a href="/about-us/events/">Events</a></li>
-              <li><a href="/about-us/join-us/">Jobs</a></li>
-              <li><a href="/about-us/contact-us/">Contact us</a></li>
+              <li><a href="https://red-badger.com/about-us/">About us</a></li>
+              <li><a href="https://red-badger.com/services/">Services</a></li>
+              <li><a href="https://red-badger.com/blog/">Blog</a></li>
+              <li><a href="https://red-badger.com/about-us/events/">Events</a></li>
+              <li><a href="https://red-badger.com/about-us/join-us/">Jobs</a></li>
+              <li><a href="https://red-badger.com/about-us/contact-us/">Contact us</a></li>
             </ul>
           </nav>
         </div>

--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -33,7 +33,7 @@ const Header = () => {
               <li><a href="/">Home</a></li>
               <li><a href="https://red-badger.com/about-us/">About us</a></li>
               <li><a href="https://red-badger.com/services/">Services</a></li>
-              <li><a href="https://red-badger.com/blog/">Blog</a></li>
+              <li><a href="http://red-badger.com/blog/">Blog</a></li>
               <li><a href="https://red-badger.com/about-us/events/">Events</a></li>
               <li><a href="https://red-badger.com/about-us/join-us/">Jobs</a></li>
               <li><a href="https://red-badger.com/about-us/contact-us/">Contact us</a></li>

--- a/site/pages/case-studies/index.js
+++ b/site/pages/case-studies/index.js
@@ -44,34 +44,38 @@ export default function caseStudies() {
         </div>
       </div>
       <div className={cx('caseStudyContainer', 'inverse')}>
-        <a className={cx('imageLink', 'camden')} href="https://red-badger.com/our-work/case-study/camden-market/">
-          <img alt="The Camden Market App" src={camdenJpg} />
-        </a>
-        <div className={styles.caseStudyTextContainer}>
-          <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/camden-market/">Camden Market</a>
-          <div className={styles.caseStudyTitleContainer}>
-            <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/camden-market/">Taking steps towards a digital future</a>
-          </div>
-          <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/camden-market/">
-            Built in just ten weeks, Camdenmarket.com relaunched in May 2016 to drive
-            more footfall from Londoners to the physical market by
-            showcasing the eclectic range of goods, food and events.
+        <div>
+          <a className={cx('imageLink', 'camden')} href="https://red-badger.com/our-work/case-study/camden-market/">
+            <img alt="The Camden Market App" src={camdenJpg} />
           </a>
+          <div className={styles.caseStudyTextContainer}>
+            <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/camden-market/">Camden Market</a>
+            <div className={styles.caseStudyTitleContainer}>
+              <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/camden-market/">Taking steps towards a digital future</a>
+            </div>
+            <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/camden-market/">
+              Built in just ten weeks, Camdenmarket.com relaunched in May 2016 to drive
+              more footfall from Londoners to the physical market by
+              showcasing the eclectic range of goods, food and events.
+            </a>
+          </div>
         </div>
       </div>
       <div className={styles.caseStudyContainer}>
-        <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/financial-times/">
-          <img alt="Financial Times website on a tablet" src={financialTimesJpg} />
-        </a>
-        <div className={styles.caseStudyTextContainer}>
-          <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/financial-times/">Financial Times</a>
-          <div className={styles.caseStudyTitleContainer}>
-            <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/financial-times/">Lasting change for a media giant</a>
-          </div>
-          <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/financial-times/">
-            Improving online and mobile conversion rates on the new fortnumandmason.com
-            site with great customer experience and innovative tech.
+        <div>
+          <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/financial-times/">
+            <img alt="Financial Times website on a tablet" src={financialTimesJpg} />
           </a>
+          <div className={styles.caseStudyTextContainer}>
+            <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/financial-times/">Financial Times</a>
+            <div className={styles.caseStudyTitleContainer}>
+              <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/financial-times/">Lasting change for a media giant</a>
+            </div>
+            <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/financial-times/">
+              Improving online and mobile conversion rates on the new fortnumandmason.com
+              site with great customer experience and innovative tech.
+            </a>
+          </div>
         </div>
       </div>
       <div className={styles.buttonContainer}>

--- a/site/pages/case-studies/index.js
+++ b/site/pages/case-studies/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import classnames from 'classnames/bind';
 import styles from './style.css';
 import TechSlice from '../../slices/tech-slice';
-
 /* PNG and Jpg  imports */
 import camdenJpg from './JPG/camden.jpg';
 import financialTimesJpg from './JPG/financialtimes.jpg';
@@ -27,7 +26,7 @@ export default function caseStudies() {
         <h2 className={styles.subHeader}>Read some of our case studies.</h2>
       </div>
       <div className={styles.caseStudyContainer}>
-        <div>
+        <div className={styles.caseStudyContent}>
           <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
             <img alt="The logo of Fortnum & Mason" src={fortnumJpg} />
           </a>
@@ -44,7 +43,7 @@ export default function caseStudies() {
         </div>
       </div>
       <div className={cx('caseStudyContainer', 'inverse')}>
-        <div>
+        <div className={styles.caseStudyContent}>
           <a className={cx('imageLink', 'camden')} href="https://red-badger.com/our-work/case-study/camden-market/">
             <img alt="The Camden Market App" src={camdenJpg} />
           </a>
@@ -62,7 +61,7 @@ export default function caseStudies() {
         </div>
       </div>
       <div className={styles.caseStudyContainer}>
-        <div>
+        <div className={styles.caseStudyContent}>
           <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/financial-times/">
             <img alt="Financial Times website on a tablet" src={financialTimesJpg} />
           </a>

--- a/site/pages/case-studies/index.js
+++ b/site/pages/case-studies/index.js
@@ -27,18 +27,20 @@ export default function caseStudies() {
         <h2 className={styles.subHeader}>Read some of our case studies.</h2>
       </div>
       <div className={styles.caseStudyContainer}>
-        <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
-          <img alt="The logo of Fortnum & Mason" src={fortnumJpg} />
-        </a>
-        <div className={styles.caseStudyTextContainer}>
-          <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">Fortnum & Mason</a>
-          <div className={styles.caseStudyTitleContainer}>
-            <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">Elegant e-commerce in eight months</a>
-          </div>
-          <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
-            Improving online and mobile conversion rates on the new fortnumandmason.com
-            site with great customer experience and innovative tech.
+        <div>
+          <a className={styles.imageLink} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
+            <img alt="The logo of Fortnum & Mason" src={fortnumJpg} />
           </a>
+          <div className={styles.caseStudyTextContainer}>
+            <a className={styles.caseStudyCompany} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">Fortnum & Mason</a>
+            <div className={styles.caseStudyTitleContainer}>
+              <a className={styles.caseStudyTitle} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">Elegant e-commerce in eight months</a>
+            </div>
+            <a className={styles.caseStudyDescription} href="https://red-badger.com/our-work/case-study/fortnum-and-mason/">
+              Improving online and mobile conversion rates on the new fortnumandmason.com
+              site with great customer experience and innovative tech.
+            </a>
+          </div>
         </div>
       </div>
       <div className={cx('caseStudyContainer', 'inverse')}>

--- a/site/pages/case-studies/style.css
+++ b/site/pages/case-studies/style.css
@@ -49,6 +49,9 @@
   padding: 30px 20px 30px 20px;
   background-color: white;
 }
+.caseStudyContainer {
+  display: flex;
+}
 
 a {
   text-decoration: none;

--- a/site/pages/case-studies/style.css
+++ b/site/pages/case-studies/style.css
@@ -121,6 +121,11 @@ a {
   .caseStudyContainer {
     display: flex;
     padding: 60px;
+    justify-content: center;
+  }
+  .caseStudyContainer div {
+    display: flex;
+    max-width: 1440px;
   }
 
   .caseStudyTextContainer {

--- a/site/pages/case-studies/style.css
+++ b/site/pages/case-studies/style.css
@@ -123,7 +123,7 @@ a {
     padding: 60px;
     justify-content: center;
   }
-  .caseStudyContainer div {
+  .caseStudyContent {
     display: flex;
     max-width: 1440px;
   }

--- a/site/pages/case-studies/style.css
+++ b/site/pages/case-studies/style.css
@@ -99,7 +99,6 @@ a {
 
 .inverse {
   background-color: black;
-  flex-direction: row-reverse;
 }
 
 .inverse .caseStudyTitle, .inverse .caseStudyDescription {
@@ -126,6 +125,10 @@ a {
   .caseStudyContent {
     display: flex;
     max-width: 1440px;
+    width: 100%;
+  }
+  .inverse .caseStudyContent {
+    flex-direction: row-reverse;
   }
 
   .caseStudyTextContainer {

--- a/site/pages/case-studies/style.css
+++ b/site/pages/case-studies/style.css
@@ -37,12 +37,14 @@
   composes: fontL from "../../css/typography/_fonts.css";
   composes: serif from "../../css/typography/_fonts.css";
   text-align: center;
+  color: black;
 }
 
 .subHeader {
   composes: fontS from "../../css/typography/_fonts.css";
   composes: serif from "../../css/typography/_fonts.css";
   font-size: 16px;
+  color: black;
 }
 
 .caseStudyContainer {

--- a/site/pages/home/brie-slice/index.js
+++ b/site/pages/home/brie-slice/index.js
@@ -8,7 +8,7 @@ const Brie = () => (
       We dig deeper to deliver the right solution by first understanding and validating the problem.
     </h2>
     <img src={BriePNG} alt="Illustration" className={styles.brie} />
-    <a href="/services/" className={styles.featureBtn}>How we work</a>
+    <a href="https://red-badger.com/services/" className={styles.featureBtn}>How we work</a>
   </section>
 );
 


### PR DESCRIPTION
Notes:
IE 11 now broke. Inverse reverse direction no longer reverses, fix

### Motivation
Changing this:
<img width="1439" alt="screen shot 2016-10-13 at 10 41 12" src="https://cloud.githubusercontent.com/assets/6062416/19344310/97e6ab44-9131-11e6-8b7e-82e17f5d59a9.png">
To this:
<img width="1432" alt="screen shot 2016-10-13 at 10 37 44" src="https://cloud.githubusercontent.com/assets/6062416/19344235/47659162-9131-11e6-9b66-954f7f5afe87.png">

And also making the header and footer links actually link somewhere. Also ensuring that the How we work links to the correct page. Also that the case studies link to the correct place'

### Test plan

Check that the logo in the footer is on the far right in all browsers. Check all the header and footer links actually link to the correct places.

### Pre-merge checklist

- [x] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
- [ ] Tester approved

