### PR TITLE
Add Google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Red Badger Website Episode 6: Return of the Jedi.
 * [Usage](#usage)
 * [Dev setup](#dev-setup)
 * [Technical Overview](#technical-overview)
+* [Environment Variables](https://github.com/redbadger/website-honestly/blob/master/docs/environment-variables.md)
 
 
 ## Usage

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -24,4 +24,4 @@ The email address that AWS Lambda error notifications will be sent to.
 
 ## `INSERT_TRACKING`
 
-If set Google Analytics tracking scripts will be inserted into the page.
+If set Google Analytics/leadforensics tracking scripts will be inserted into the page.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,27 @@
+Environment Variables
+=====================
+
+This site uses several environment variables. These are set in `.env` in dev.
+In prod they are set in `circle.yml`, deploy scripts, and in CircleCI's
+secrets vault.
+
+
+## `ENVIRONMENT_NAME`
+
+A name used to make the stack unique. Prod's is `prod`. Staging's is
+`staging`. Mine is `louis`.
+
+
+## `CONTACT_US_EMAIL_TO`
+
+The email address that contact requests will be sent to.
+
+
+## `CONTACT_US_SUPPORT_EMAIL`
+
+The email address that AWS Lambda error notifications will be sent to.
+
+
+## `INSERT_TRACKING`
+
+If set Google Analytics tracking scripts will be inserted into the page.

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -6,6 +6,8 @@ import { registerStateNavigator } from '../../site/components/link';
 import layoutTemplate from '../index.ejs';
 import { cssPath, jsPath } from './asset-paths';
 
+const tracking = !!process.env.INSERT_TRACKING;
+
 export function compileRoutes(siteRoutes) {
   const stateNavigator = new Navigation.StateNavigator(
     siteRoutes,
@@ -16,7 +18,7 @@ export function compileRoutes(siteRoutes) {
     const Component = route.component;
     const path = route.filePath;
     const bodyContent = renderToString(<Component />);
-    const body = layoutTemplate({ bodyContent, cssPath, jsPath });
+    const body = layoutTemplate({ tracking, bodyContent, cssPath, jsPath });
     return { body, path };
   });
 }

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -40,6 +40,6 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-16654919-1', 'auto');
 ga('send', 'pageview');
-    </script><% } %>
+    </script><script type="text/javascript" src="https://secure.leadforensics.com/js/77932.js" /><noscript><img src="https://secure.leadforensics.com/77932.png" style={{ display: 'none' }} /></noscript><% } %>
   </body>
 </html>

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -32,5 +32,14 @@
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
+    <% if (typeof tracking !== 'undefined' && tracking) { %><script type="text/javascript">
+var _gaq = _gaq || [];
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-16654919-1', 'auto');
+ga('send', 'pageview');
+    </script><% } %>
   </body>
 </html>


### PR DESCRIPTION
### Motivation

We wish to have usage analytics for the new site.

### Test plan

- Once master is ready it will inject javascript into the bottom of each page. View this in the page source.
- This Javascript will make a request to google analytics and leadforensics (`77932.js`). Open the network tab and refresh to see.

### Pre-merge checklist

- [x] ~~Unit tests~~
- [ ] Reviews
  - [ ] Code review
  - [x] ~~Design review~~
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

