### PR TITLE
Add 301 redirects for changed paths

### DIFF
--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -51,6 +51,27 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: 404/index.html
+          RoutingRules:
+            - RoutingRuleCondition:
+                KeyPrefixEquals: "services"
+              RedirectRule:
+                HttpRedirectCode: "301"
+                ReplaceKeyWith: "what-we-do"
+            - RoutingRuleCondition:
+                KeyPrefixEquals: "services/technology"
+              RedirectRule:
+                HttpRedirectCode: "301"
+                ReplaceKeyWith: "what-we-do/technology"
+            - RoutingRuleCondition:
+                KeyPrefixEquals: "our-work"
+              RedirectRule:
+                HttpRedirectCode: "301"
+                ReplaceKeyWith: "what-we-do/our-work"
+            - RoutingRuleCondition:
+                KeyPrefixEquals: "about-us/contact-us"
+              RedirectRule:
+                HttpRedirectCode: "301"
+                ReplaceKeyWith: ""
 
     SiteContentBucketPolicy:
       Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
### Motivation

- [New paths document](https://docs.google.com/spreadsheets/d/1YV0KgYtq1yMkXrV1ow9BYxFsjL0Dn3kxCX8HadUPlwc/edit#gid=0)

We would like users to find the correct page if they try to visit old paths.

### Test plan

- "services" goes to "what-we-do"
- "services/technology" goes to "what-we-do/technology"
- "our-work" goes to "what-we-do/our-work"
- "about-us/contact-us" goes to ""

### Pre-merge checklist

- [x] ~~Unit tests~~
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing (no browser checking required)
- [ ] Tester approved

