### PR TITLE
Fixing favicons

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -19,11 +19,11 @@
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-144x144.png" type="image/png" sizes="144x144">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png" type="image/png" sizes="152x152">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-180x180.png" type="image/png" sizes="180x180">
-    <link rel="icon" href="/favicon-16x16.png" type="image/png" sizes="16x16">
-    <link rel="icon" href="/favicon-32x32.png" type="image/png" sizes="32x32">
-    <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
-    <link rel="icon" href="/favicon-192x192.png" type="image/png" sizes="192x192">
-    <link rel="icon" href="/favicon-194x194.png" type="image/png" sizes="194x194">
+    <link rel="icon" href="/assets/favicons/favicon-16x16.png" type="image/png" sizes="16x16">
+    <link rel="icon" href="/assets/favicons/favicon-32x32.png" type="image/png" sizes="32x32">
+    <link rel="icon" href="/assets/favicons/favicon-96x96.png" type="image/png" sizes="96x96">
+    <link rel="icon" href="/assets/favicons/favicon-192x192.png" type="image/png" sizes="192x192">
+    <link rel="icon" href="/assets/favicons/favicon-194x194.png" type="image/png" sizes="194x194">
     <title>Red Badger</title>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>
   </head>


### PR DESCRIPTION
![giphy 2](https://cloud.githubusercontent.com/assets/487468/19434240/40863224-945c-11e6-80d1-f0bff6f120cc.gif)

### Motivation

Favicons card

### Test plan

- Verify that favicon is correctly displayed on all browsers
- Try saving bookmarks on those browsers and verify that favicon is still there
- On touch devices try saving bookmark on home screen and verify that correct retina grade favicon is applied

### Pre-merge checklist

- [ ] Unit tests - N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

