### PR TITLE
Close menu by clicking on the outside

### DIFF
--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import InlineSVG from 'svg-inline-react';
+
+import SmallScreenNav from './small-screen-nav';
+
 import styles from './style.css';
 import logoSVG from './rb-logo-placeholder.svg';
 
@@ -19,28 +22,7 @@ const Header = () => {
         </ul>
       </nav>
 
-      <div className={styles.triggerContainer}>
-        <label htmlFor="burger" className={styles.triggerLabel}>MENU</label>
-      </div>
-      <input type="checkbox" className={styles.trigger} id="burger" />
-
-      <div className={styles.overlay}>
-        <div>
-          <label htmlFor="burger" className={styles.menuCloseButton}>Close</label>
-
-          <nav className={styles.smallScreenNavContainer} role="navigation">
-            <ul className={styles.smallScreenNav}>
-              <li><a href="/">Home</a></li>
-              <li><a href="/about-us/">About us</a></li>
-              <li><a href="/what-we-do/">What we do</a></li>
-              <li><a href="http://red-badger.com/blog/">Blog</a></li>
-              <li><a href="/about-us/events/">Events</a></li>
-              <li><a href="/about-us/join-us/">Jobs</a></li>
-              <li><a href="/about-us/contact-us/">Contact us</a></li>
-            </ul>
-          </nav>
-        </div>
-      </div>
+      <SmallScreenNav />
 
     </header>
   );

--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -1,0 +1,49 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+
+import React from 'react';
+
+import styles from './style.css';
+
+export default class SmallScreenNav extends React.Component {
+  closeMenu = () => {
+    this.input.checked = false;
+  }
+
+  render() {
+    return (
+      <div className={styles.smallScreenNavComponent}>
+        <div className={styles.triggerContainer}>
+          <label htmlFor="burger" className={styles.triggerLabel}>MENU</label>
+        </div>
+        <input
+          type="checkbox"
+          className={styles.trigger}
+          id="burger"
+          ref={c => { this.input = c; }}
+        />
+
+        <div className={styles.overlay}>
+          <div
+            className={styles.smallScreenNavMargin}
+            onClick={this.closeMenu}
+          />
+          <div className={styles.smallScreenNavWrapper}>
+            <label htmlFor="burger" className={styles.menuCloseButton}>Close</label>
+
+            <nav className={styles.smallScreenNavContainer} role="navigation">
+              <ul className={styles.smallScreenNav}>
+                <li><a href="/">Home</a></li>
+                <li><a href="/about-us/">About us</a></li>
+                <li><a href="/what-we-do/">What we do</a></li>
+                <li><a href="http://red-badger.com/blog/">Blog</a></li>
+                <li><a href="/about-us/events/">Events</a></li>
+                <li><a href="/about-us/join-us/">Jobs</a></li>
+                <li><a href="/about-us/contact-us/">Contact us</a></li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -154,4 +154,8 @@
   .logo svg {
     height: 30px;
   }
+
+  .smallScreenNavComponent {
+    width: auto;
+  }
 }

--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -116,8 +116,10 @@
 
 .triggerContainer {
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: flex-end;
+  align-items: flex-end;
 }
 
 .triggerLabel {

--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -43,7 +43,6 @@
 }
 
 .overlay {
-  background: black;
   position: fixed;
   top: 0;
   right: -100%;
@@ -56,6 +55,23 @@
   font-weight: bold;
 
   transition: left 0.3s;
+}
+
+.smallScreenNavMargin {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 44px;
+}
+
+.smallScreenNavWrapper {
+  background: black;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 44px;
 }
 
 .overlay .mediumScreenNav {
@@ -94,6 +110,10 @@
   cursor: pointer;
 }
 
+.smallScreenNavComponent {
+  width: 100%;
+}
+
 .triggerContainer {
   width: 100%;
   display: flex;
@@ -116,7 +136,7 @@
 }
 
 .trigger:checked + .overlay {
-  left: 44px;
+  left: 0;
   right: 0;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,8 +792,8 @@ babel-types@^6.0.19, babel-types@^6.14.0, babel-types@^6.15.0, babel-types@^6.16
     to-fast-properties "^1.0.1"
 
 babylon@^6.0.18:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.12.0.tgz#953e6202e58062f7f5041fc8037e4bd4e17140a9"
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.13.0.tgz#58ed40dd2a8120612be5f318c2c0bedbebde4a0b"
 
 babylon@^6.11.0:
   version "6.11.4"
@@ -6176,4 +6176,3 @@ zip-stream@^1.1.0:
     compress-commons "^1.1.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
-


### PR DESCRIPTION
### Motivation

- Fixes #77 by enabling user to close the mobile menu by clicking outside of it

### Test plan

- Mobile menu opens and closes as expected
- No other header or navigation functionality has been regressed

### Pre-merge checklist

- [x] Unit tests N/A
- [x] Reviews
  - [x] Code review
  - [x] Design review N/A
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
- [ ] Tester approved

