### PR TITLE
Removing S3 bucket redirects

### DIFF
--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -48,27 +48,6 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: 404/index.html
-          RoutingRules:
-            - RoutingRuleCondition:
-                KeyPrefixEquals: "services"
-              RedirectRule:
-                HttpRedirectCode: "301"
-                ReplaceKeyWith: "what-we-do"
-            - RoutingRuleCondition:
-                KeyPrefixEquals: "services/technology"
-              RedirectRule:
-                HttpRedirectCode: "301"
-                ReplaceKeyWith: "what-we-do/technology"
-            - RoutingRuleCondition:
-                KeyPrefixEquals: "our-work"
-              RedirectRule:
-                HttpRedirectCode: "301"
-                ReplaceKeyWith: "what-we-do/our-work"
-            - RoutingRuleCondition:
-                KeyPrefixEquals: "about-us/contact-us"
-              RedirectRule:
-                HttpRedirectCode: "301"
-                ReplaceKeyWith: ""
 
     SiteContentBucketPolicy:
       Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
![giphy 7](https://cloud.githubusercontent.com/assets/487468/19689872/b585b2be-9ac6-11e6-9f2b-e73c9c7fe358.gif)

### Motivation

Because all redirects are performed on Website Next Proxy level, this config is clashing with nginx proxy config and should be removed.

### Test plan

- This should be tested in conjunction with the Website Next Proxy changes on staging environment. This change can only be tested once it is merged and deployed, since it is affecting infrastructure config.

### Pre-merge checklist

- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

