### PR TITLE
Use HTTPS links for branch previews

### DIFF
--- a/bin/register-github-deployment.js
+++ b/bin/register-github-deployment.js
@@ -17,10 +17,9 @@ const env = key => {
   process.exit(1);
 };
 
-const environment = env('ENVIRONMENT_NAME');
 const gitHubUsername = env('GITHUB_USERNAME');
 const gitHubToken = env('GITHUB_TOKEN');
-const targetUrl = `http://rb-website-honestly--${environment}.s3-website-eu-west-1.amazonaws.com/${ref}/`;
+const targetUrl = `https://www-staging.red-badger.com/${ref}/`;
 const environmentUrl = targetUrl;
 
 const creds = `${gitHubUsername}:${gitHubToken}`;


### PR DESCRIPTION
### Motivation

We want HTTP on the branch previews to enable security and fancy features like service workers.

### Test plan

Deployment link goes to the www-staging url

### Pre-merge checklist

- [x] Reviews
  - [x] Code review
- [ ] Tester approved

