### PR TITLE
Removing CloudFront config from Cloudformation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make services-deploy
 
 ## Technical Overview
 
-This site is a static site hosted on AWS S3 behind AWS Cloudfront.
+This site is a static site hosted on AWS S3 behind a proxy that provides HTTPS. You can find the proxy here https://github.com/redbadger/website-next-proxy
 
 The React template system is used to compile the pages, and it is run on AWS
 Lambda.

--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -77,39 +77,6 @@ resources:
               Resource:
                 - "arn:aws:s3:::${self:custom.bucket_name}/*"
 
-    SiteCloudfrontDistribution:
-      Type: "AWS::CloudFront::Distribution"
-      Properties:
-        DistributionConfig:
-          Origins:
-            - DomainName: "${self:custom.bucket_name}.s3.amazonaws.com"
-              Id: "S3Origin"
-              CustomOriginConfig:
-                HTTPPort: "80"
-                HTTPSPort: "443"
-                OriginProtocolPolicy: "https-only"
-          CustomErrorResponses:
-            - ErrorCachingMinTTL : 20
-              ErrorCode: 404
-              ResponseCode: 404
-              ResponsePagePath: "/404.html"
-          Enabled: "true"
-          PriceClass: "PriceClass_200"
-          DefaultRootObject: "index.html"
-          DefaultCacheBehavior:
-            TargetOriginId: "S3Origin"
-            ViewerProtocolPolicy: "allow-all"
-            AllowedMethods:
-              - "HEAD"
-              - "GET"
-            MinTTL: 5
-            DefaultTTL: 60
-            MaxTTL: 120
-            ForwardedValues:
-              QueryString: "false"
-              Cookies:
-                Forward: "none"
-
     ErrorSNSTopic:
       Type: AWS::SNS::Topic
       Properties:


### PR DESCRIPTION
### Motivation

- Because we already have Nginx proxy in front of Old Site, Website Next and Website Honestly, there is no need for CloudFront to be in this stack. This also speeds up deployments and simplifies routing.

### Test plan

- Try accessing the site
- Try accessing /what-we-do URL

### Pre-merge checklist

- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

