### PR TITLE
FIX: Prevent home animation from running twice

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -28,6 +28,9 @@
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>
   </head>
   <body>
+    <noscript>
+      <style>.js-enabled-only { display: none; }</style>
+    </noscript>
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>

--- a/site/pages/home/homepage-top-slice/index.js
+++ b/site/pages/home/homepage-top-slice/index.js
@@ -4,18 +4,31 @@ import styles from './style.css';
 
 const cx = classnames.bind(styles);
 
-const HomepageTopSlice = () => {
+function Slogan() {
+  return (
+    <div className={cx('sliceContainer', 'fadeInUp')}>
+      <h1 className={styles.badgerSlogan}>Let’s make<br />things better.</h1>
+
+      <p className={styles.sloganDescription}>
+        We work with you to deliver digital products that
+        make a difference to people.
+      </p>
+    </div>
+  );
+}
+
+function HomepageTopSlice() {
   return (
     <section className={styles.homepageTopSlice}>
-      <div className={styles.sliceContainer}>
-        <h1 className={cx('badgerSlogan', 'fadeInUp')}>Let’s make<br />things better.</h1>
-        <p className={cx('sloganDescription', 'fadeInUp')}>
-          We work with you to deliver digital products that
-          make a difference to people.
-        </p>
+      <div className="js-enabled-only">
+        <Slogan />
       </div>
+
+      <noscript>
+        <Slogan />
+      </noscript>
     </section>
   );
-};
+}
 
 export default HomepageTopSlice;


### PR DESCRIPTION
### Motivation

Header animation plays twice. This fixes the bug.

Fixes https://github.com/redbadger/website-honestly/issues/110

### Test plan

- Header animation doesn't play twice.

### Pre-merge checklist

- [ ] Reviews
  - [ ] Code review
- [ ] Manual testing
  - [x] Ubuntu 16.04 Chrome
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

