### PR TITLE
Pyramid slice images on mobile

### DIFF
--- a/site/pages/what-we-do/triangle-slice/style.css
+++ b/site/pages/what-we-do/triangle-slice/style.css
@@ -48,7 +48,6 @@
 
 .mobileTriangleImage {
   width: 50%;
-  height: 50%;
 }
 
 .rightThingText {


### PR DESCRIPTION
### Motivation

- Pyramid slice images on mobile disappeared

### Test plan

- Pyramid slice isn't missing any images or information on any device :)

### Pre-merge checklist

- [x] Unit tests N/A
- [x] Reviews
  - [x] Code review
  - [x] Design review N/A
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
- [x] Tester approved

