### PR TITLE
Removing homepage top slice title animation

### DIFF
--- a/site/pages/home/homepage-top-slice/index.js
+++ b/site/pages/home/homepage-top-slice/index.js
@@ -8,7 +8,7 @@ const HomepageTopSlice = () => {
   return (
     <section className={styles.homepageTopSlice}>
       <div className={styles.sliceContainer}>
-        <h1 className={cx('badgerSlogan', 'fadeInUp')}>Let’s make<br />things better.</h1>
+        <h1 className={styles.badgerSlogan}>Let’s make<br />things better.</h1>
         <p className={cx('sloganDescription', 'fadeInUp')}>
           We work with you to deliver digital products that
           make a difference to people.

--- a/site/pages/home/homepage-top-slice/style.css
+++ b/site/pages/home/homepage-top-slice/style.css
@@ -19,25 +19,6 @@
   composes: serif from "../../../css/typography/_fonts.css";
 }
 
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 60px, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-.fadeInUp {
-  animation-name: fadeInUp;
-  animation-iteration-count: 1;
-  animation-timing-function: cubic-bezier(0.010, 0.830, 0.560, 1.010);
-  animation-duration: 1.2s;
-}
-
 @media mediumScreen {
   .homepageTopSlice {
     text-align: left;


### PR DESCRIPTION
### Motivation

- #110 issue when animation is performed twice. We're removing animation for go live, and release a fix after the dust settles.

### Test plan

- Test that homepage top title slogan animation is absent.

### Pre-merge checklist

- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

