### PR TITLE
Accessibility changes to nav

### DIFF
--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -11,11 +11,11 @@ const Header = () => {
   return (
     <header className={styles.header} role="banner">
       <Link to="homePage" title="Home" className={styles.logo}>
-        <InlineSVG src={logo} />
+        <InlineSVG src={logo} title="Red Badger logo" />
       </Link>
 
       <nav className={styles.mediumScreenNavContainer} role="navigation">
-        <ul className={styles.mediumScreenNav}>
+        <ul role="listbox" className={styles.mediumScreenNav}>
           <li>
             <Link to="whatWeDoPage" activeCssClass={styles.activeNavLink}>
               What we do

--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -6,21 +6,44 @@ import styles from './style.css';
 import Link from '../link';
 
 export default class SmallScreenNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      navOpen: false,
+    };
+  }
+
+  handleInputChange = event => {
+    this.setState({
+      navOpen: event.target.checked,
+    });
+  }
+
   closeMenu = () => {
     this.input.checked = false;
   }
 
   render() {
+    const { navOpen } = this.state;
+    const navTabIndex = navOpen ? 0 : -1;
     return (
       <div className={styles.smallScreenNavComponent}>
         <div className={styles.triggerContainer}>
-          <label htmlFor="burger" className={styles.triggerLabel}>MENU</label>
+          <label
+            htmlFor="burger"
+            className={styles.triggerLabel}
+            hidden={navOpen}
+          >
+            MENU
+          </label>
         </div>
         <input
           type="checkbox"
           className={styles.trigger}
           id="burger"
           ref={c => { this.input = c; }}
+          onChange={this.handleInputChange}
+          hidden
         />
 
         <div className={styles.overlay}>
@@ -28,18 +51,21 @@ export default class SmallScreenNav extends React.Component {
             className={styles.smallScreenNavMargin}
             onClick={this.closeMenu}
           />
-          <div className={styles.smallScreenNavWrapper}>
+          <div
+            className={styles.smallScreenNavWrapper}
+            hidden={!navOpen}
+          >
             <label htmlFor="burger" className={styles.menuCloseButton}>Close</label>
 
             <nav className={styles.smallScreenNavContainer} role="navigation">
-              <ul className={styles.smallScreenNav}>
-                <li><Link to="homePage">Home</Link></li>
-                <li><a href="/about-us/">About us</a></li>
-                <li><Link to="whatWeDoPage">What we do</Link></li>
-                <li><a href="http://red-badger.com/blog/">Blog</a></li>
-                <li><a href="/about-us/events/">Events</a></li>
-                <li><a href="/about-us/join-us/">Jobs</a></li>
-                <li><a href="/about-us/contact-us/">Contact us</a></li>
+              <ul role="listbox" className={styles.smallScreenNav}>
+                <li><Link tabIndex={navTabIndex} to="homePage">Home</Link></li>
+                <li><a tabIndex={navTabIndex} href="/about-us/">About us</a></li>
+                <li><Link tabIndex={navTabIndex} to="whatWeDoPage">What we do</Link></li>
+                <li><a tabIndex={navTabIndex} href="http://red-badger.com/blog/">Blog</a></li>
+                <li><a tabIndex={navTabIndex} href="/about-us/events/">Events</a></li>
+                <li><a tabIndex={navTabIndex} href="/about-us/join-us/">Jobs</a></li>
+                <li><a tabIndex={navTabIndex} href="/about-us/contact-us/">Contact us</a></li>
               </ul>
             </nav>
           </div>


### PR DESCRIPTION
### Motivation

recreation of PR #121 to be totally up to day (it was a week old)

**on desktop**
- [x]  when navigating without a mouse, you shouldn't be able to navigate onto hidden menu items
- [x]  when using a screenreader, you shouldn't be able to hear about hidden menu items
- [x]  or hidden open/close buttons

**on mobile**
- [x]  when using a screenreader, you shouldn't be able to hear about hidden menu items
- [x] or hidden open/close buttons
- ...  you shouldn't be able to hear text below the nav bar

### Test plan

**on desktop**
- [ ]  when navigating without a mouse, you shouldn't be able to navigate onto hidden menu items
- [ ]  when using a screenreader, you shouldn't be able to hear about hidden menu items
- [ ] or hidden open/close buttons

**on mobile**
- [ ]  when using a screenreader, you shouldn't be able to hear about hidden menu items
- [ ] or hidden open/close buttons
- [ ]  you shouldn't be able to hear text below the nav bar

### Pre-merge checklist
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved
