### PR TITLE
Require valid email for contact us form

### DIFF
--- a/services/contact_us.js
+++ b/services/contact_us.js
@@ -2,13 +2,14 @@
 import aws from 'aws-sdk'; // eslint-disable-line import/no-unresolved, import/no-extraneous-dependencies
 import { validateAndSendEmail } from './ses';
 
-const contactUsEmailTo = process.env.CONTACT_US_EMAIL_TO;
-
-if (!contactUsEmailTo) {
-  throw new Error('CONTACT_US_EMAIL_TO environment variable not set!');
-}
 
 export default function doContactUs(event, cb) {
+  const contactUsEmailTo = process.env.CONTACT_US_EMAIL_TO;
+
+  if (!contactUsEmailTo) {
+    throw new Error('CONTACT_US_EMAIL_TO environment variable not set!');
+  }
+
   const data = {
     emailTo: contactUsEmailTo,
     message: event.body.message,

--- a/services/ses/index.js
+++ b/services/ses/index.js
@@ -4,7 +4,7 @@ const contactLabel = 'Contact details:';
 const fieldMessages = {
   emailTo: 'Must be present',
   message: 'How can we help? Let us know in the box below.',
-  contact: 'Please let us know the best way of contacting you.',
+  contact: 'Please let us know your email address.',
 };
 
 function filterInternalErrors(error) {
@@ -15,6 +15,11 @@ function filterInternalErrors(error) {
     };
   }
   throw error;
+}
+
+function validateContact(contact) {
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line max-len
+  return re.test(contact);
 }
 
 function throwValidationError(errors) {
@@ -30,6 +35,11 @@ function validateEmail(email) {
       return Object.assign(errors, {
         [field]: fieldMessages[field],
       });
+    }
+    if (field === 'contact' && !validateContact(email.contact)) {
+      return {
+        contact: fieldMessages.contact,
+      };
     }
     return errors;
   };

--- a/services/ses/index.js
+++ b/services/ses/index.js
@@ -17,9 +17,9 @@ function filterInternalErrors(error) {
   throw error;
 }
 
-function validateContact(contact) {
-  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line max-len
-  return re.test(contact);
+export function validateContact(contact) {
+  const regex = /.+@.+\..+/;
+  return regex.test(contact);
 }
 
 function throwValidationError(errors) {

--- a/services/ses/test.js
+++ b/services/ses/test.js
@@ -14,7 +14,7 @@ describe('contact-us-service/email.validateAndSendEmail', () => {
       errors: {
         emailTo: 'Must be present',
         message: 'How can we help? Let us know in the box below.',
-        contact: 'Please let us know the best way of contacting you.',
+        contact: 'Please let us know your email address.',
       },
     });
   });
@@ -50,7 +50,19 @@ describe('contact-us-service/email.validateAndSendEmail', () => {
     return expect(promise).to.eventually.deep.equal({
       success: false,
       errors: {
-        contact: 'Please let us know the best way of contacting you.',
+        contact: 'Please let us know your email address.',
+      },
+    });
+  });
+
+  it('resolves with error if contact is not an email address', () => {
+    const email = Object.assign({}, defaultEmail);
+    email.contact = '07546575829';
+    const promise = validateAndSendEmail(email);
+    return expect(promise).to.eventually.deep.equal({
+      success: false,
+      errors: {
+        contact: 'Please let us know your email address.',
       },
     });
   });

--- a/site/pages/home/contact-us-slice/form/index.js
+++ b/site/pages/home/contact-us-slice/form/index.js
@@ -48,7 +48,7 @@ class Form extends Component {
           />
 
           <label className={styles.formLabel} htmlFor="contact">
-            Your email or phone:&nbsp;
+            Your email:&nbsp;
             <span className={styles.errorMessage}>{errors.contact}</span>
           </label>
           <input


### PR DESCRIPTION
### Motivation

In order to make our Contact Us form more resilient, we decided to require an email when users are submitting a Contact Us form. In other words, @AndreiDanielIonescu was right :D

### Test plan

- Check you can send email via contact us form
- Check you can't do it if there isn't a valid email submitted

### Pre-merge checklist

- [x] Documentation (does it need any?)
- [x] Unit tests
- [ ] Reviews
  - [x] Code review
  - [x] Design review N/A
- [x] Manual testing (probably not necessary as it is mainly back-end/js change?)
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
- [ ] Tester approved

