### PR TITLE
Removing service worker registration

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -14,10 +14,6 @@ export function makeApp({ element, data, history }) {
   );
   registerStateNavigator(stateNavigator);
 
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register(location.origin + '/sw.js');
-  }
-
   routes.forEach(route => {
     const render = () => {
       window.scrollTo(0, 0);


### PR DESCRIPTION
### Motivation

- #182 we're having issues when http images from blog are being loaded on the old site. There is no way of limiting scope of the SW in a smart way. Hence we're going to disable it for now, and bring back once the blog has migrated to be https only.

### Test plan

- Load site. Open devtools on Chrome and check that no service worker has been registered. You might have to unregister old service worker.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

