### PR TITLE
Enabling Service Worker on client

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -14,6 +14,10 @@ export function makeApp({ element, data, history }) {
   );
   registerStateNavigator(stateNavigator);
 
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register(location.origin + '/sw.js');
+  }
+
   routes.forEach(route => {
     const render = () => {
       window.scrollTo(0, 0);


### PR DESCRIPTION
### Motivation

- Service Worker was temporarily disabled until blog is migrated to be https only. Now it's time to bring it back.

### Test plan

- Run the site. Check in Chrome devtools that Service Worker is up and running. Open the site. Disable internet access. Reload site. It should still work.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

