### PR TITLE
Expose Publish Lambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,9 @@ services-deploy: dist/services.zip ## Upload the publish service to AWS Lambda
 	$(LOAD_ENV) \
 	&& $(SERVERLESS) deploy
 
-
 publish-service-invoke: ## Invoke the publish service
 	$(LOAD_ENV) \
-	&& $(SERVERLESS) invoke --function publish
-
+	&& curl --fail $$PUBLISH_ENDPOINT
 
 compress-assets: ## Compress assets. What did you expect? :)
 	find site -type f \

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ services-deploy: dist/services.zip ## Upload the publish service to AWS Lambda
 
 publish-service-invoke: ## Invoke the publish service
 	$(LOAD_ENV) \
-	&& curl --fail $$PUBLISH_ENDPOINT
+	&& curl -XPOST --fail $$PUBLISH_ENDPOINT
 
 compress-assets: ## Compress assets. What did you expect? :)
 	find site -type f \

--- a/services/index.js
+++ b/services/index.js
@@ -4,6 +4,10 @@ import doSignUp from './mailchimp/sign-up/index';
 import doUpdateUser from './mailchimp/update-user/index';
 
 export function publish(event, context, cb) {
+  if (event.query && event.query.auth_token !== process.env.PRIVATE_LAMBDA_API_KEY) {
+    return cb(new Error('[403] Forbidden'));
+  }
+
   try {
     doPublish(cb);
   } catch (e) {

--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -29,6 +29,11 @@ provider:
 functions:
   publish:
     handler: index.publish
+    events:
+      - http:
+          path: publish
+          method: post
+          cors: true
   contactUs:
     handler: index.contactUs
     events:


### PR DESCRIPTION
### Motivation

Exposing the publish lambda as a HTTP endpoint. This endpoint is protected by an API key to prevent unauthorized usage.

This means we can trigger a rebuild from BadgerBot, Prismic Webhooks etc.

### Test plan

- Visit the secret `PUBLISH_ENDPOINT` to trigger a deployment. Confirm a deployment was indeed triggered.
