### PR TITLE
Smaller confused badger on mobile

### DIFF
--- a/site/components/error-page/style.css
+++ b/site/components/error-page/style.css
@@ -43,7 +43,7 @@
 .badger {
   display: inline;
   float: right;
-  max-height: 141px;
+  max-height: 120px;
   margin-bottom: 30px;
 }
 


### PR DESCRIPTION
### Motivation

Small design change - badger was too large on our smaller devices. Made it slightly smaller so the text is easier to read.

### Test plan

Open on mobile devices.

### Pre-merge checklist

  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome

