### PR TITLE
Moving LeadForensics and GA scripts to the page head

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -31,13 +31,9 @@
     <link rel="icon" href="/assets-honestly/favicons/favicon-194x194.png" type="image/png" sizes="194x194">
     <title><% if (typeof title !== 'undefined') {%><%= title %><% } %></title>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>
-  </head>
-  <body>
-    <div class="js-app">
-      <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
-    </div>
-    <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
-    <% if (typeof tracking !== 'undefined' && tracking) { %><script type="text/javascript">
+    <% if (typeof tracking !== 'undefined' && tracking) { %>
+    <script type="text/javascript" src="https://secure.leadforensics.com/js/77932.js" /><noscript><img src="https://secure.leadforensics.com/77932.png" style="display: none;" /></noscript>
+    <script type="text/javascript">
 var _gaq = _gaq || [];
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -45,7 +41,13 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-16654919-1', 'auto');
 ga('send', 'pageview');
-    </script><script type="text/javascript" src="https://secure.leadforensics.com/js/77932.js" /><noscript><img src="https://secure.leadforensics.com/77932.png" style="display: none;" /></noscript><% } %>
+    </script><% } %>
+  </head>
+  <body>
+    <div class="js-app">
+      <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
+    </div>
+    <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </body>
 </html>


### PR DESCRIPTION
### Motivation

- LeadForensics is currently under reporting visits count as compared to the GA. This is likely due to LF script being at the very bottom of the page.

### Test plan

- Deploy to live and monitor the situation for a few days. Compare visits count on GA and LF.

### Pre-merge checklist

None of these apply since this should be verified in live environment by following the visits reports.

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved