### PR TITLE
Rehydrate State on the Client

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -3,14 +3,9 @@ import 'whatwg-fetch';
 
 import Navigation from 'navigation';
 import { makeApp } from '../site/client';
-import getSiteState from '../state';
 
-getSiteState()
-  .then(state => {
-    const element = document.querySelector('.js-app');
-    const history = new Navigation.HTML5HistoryManager();
-    return makeApp({ element, state, history });
-  })
-  .then(app => {
-    app.start();
-  });
+const element = document.querySelector('.js-app');
+const history = new Navigation.HTML5HistoryManager();
+const state = window.state;
+
+makeApp({ element, state, history }).start();

--- a/client/index.js
+++ b/client/index.js
@@ -6,6 +6,6 @@ import { makeApp } from '../site/client';
 
 const element = document.querySelector('.js-app');
 const history = new Navigation.HTML5HistoryManager();
-const state = window.state;
+const state = JSON.parse(document.body.getAttribute('data-state') || '{}');
 
 makeApp({ element, state, history }).start();

--- a/client/index.js
+++ b/client/index.js
@@ -6,6 +6,6 @@ import { makeApp } from '../site/client';
 
 const element = document.querySelector('.js-app');
 const history = new Navigation.HTML5HistoryManager();
-const state = JSON.parse(document.body.getAttribute('data-state') || '{}');
+const state = JSON.parse(document.getElementById('state').value);
 
 makeApp({ element, state, history }).start();

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "webpack-dev-server": "^1.15.2",
     "webpack-merge": "^0.14.1",
     "whatwg-fetch": "^1.0.0",
-    "xmldom": "^0.1.22"
+    "xmldom": "^0.1.22",
+    "xss-filters": "^1.2.7"
   },
   "repository": {
     "type": "git",

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -1,5 +1,7 @@
 import { renderToString } from 'react-dom/server';
 import Navigation from 'navigation';
+import xssFilters from 'xss-filters';
+
 import makeRoutes from '../routes';
 import layoutTemplate from '../index.ejs';
 import { cssPath, jsPath } from './asset-paths';
@@ -66,7 +68,7 @@ export function compileRoutes(siteRoutes, state) {
       bodyContent,
       cssPath,
       jsPath,
-      state,
+      state: xssFilters.inDoubleQuotedAttr(JSON.stringify(state)),
     });
 
     return { body, path };

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -66,6 +66,7 @@ export function compileRoutes(siteRoutes, state) {
       bodyContent,
       cssPath,
       jsPath,
+      state,
     });
 
     return { body, path };

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -43,14 +43,11 @@ ga('create', 'UA-16654919-1', 'auto');
 ga('send', 'pageview');
     </script><% } %>
   </head>
-  <% if (typeof state !== 'undefined') { %>
-  <body data-state="<%= state %>">
-  <% } else { %>
-  <body data-state="{}">
-  <% } %>
+  <body>
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
+    <input id="state" type="hidden" value="<%= typeof state !== 'undefined' ? state : '{}' %>">
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </body>

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -47,6 +47,11 @@ ga('send', 'pageview');
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
+    <% if (typeof state !== 'undefined') { %>
+      <script type="text/javascript">
+        var state = <%= JSON.stringify(state) %>;
+      </script>
+    <% } %>
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </body>

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -43,15 +43,14 @@ ga('create', 'UA-16654919-1', 'auto');
 ga('send', 'pageview');
     </script><% } %>
   </head>
-  <body>
+  <% if (typeof state !== 'undefined') { %>
+  <body data-state="<%= state %>">
+  <% } else { %>
+  <body data-state="{}">
+  <% } %>
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
-    <% if (typeof state !== 'undefined') { %>
-      <script type="text/javascript">
-        var state = <%= JSON.stringify(state) %>;
-      </script>
-    <% } %>
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7407,6 +7407,10 @@ xregexp@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-3.1.1.tgz#8ee18d75ef5c7cb3f9967f8d29414a6ca5b1a184"
 
+xss-filters@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
+
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
We need to provide access to the state object used to render the site if we'd like React to take over client-side rendering.

At the moment this places the entire state blob on every page. Obviously, this isn't ideal, but I plan to thread this object through something similar to `stateToProps` for each relevant route to reduce the props to only those relevant for each route.

As a simple first pass though, this solution will unblock us.