### PR TITLE
Increase Timeout for Publish Lambda

### DIFF
--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -29,6 +29,7 @@ provider:
 functions:
   publish:
     handler: index.publish
+    timeout: 60
     events:
       - http:
           path: publish


### PR DESCRIPTION
### Motivation

Serverless sets this at 6 seconds, which might not always be sufficient.

### Test plan

Deploys should not timeout in CircleCI 👍 

### Pre-merge checklist

*Not Applicable*

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
