### PR TITLE
Change dev to use HTML5 History to match dev-static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-deps: ## Check deps for updates
 
 
 dev: badger dist/sw.js ## Run the frontend dev server
-	$(LOAD_ENV) && $(WEBPACK_DEV_SERVER) --hot --inline --config webpack.dev.browser.config.js --content-base dist/
+	$(LOAD_ENV) && $(WEBPACK_DEV_SERVER) --hot --inline --config webpack.dev.browser.config.js --content-base dist/ --history-api-fallback
 
 
 sw: dist/sw.js  ## Compile service worker

--- a/client/index.js
+++ b/client/index.js
@@ -1,11 +1,9 @@
 import 'es6-promise/auto';
 import 'whatwg-fetch';
 
-import Navigation from 'navigation';
 import { makeApp } from '../site/client';
 
 const element = document.querySelector('.js-app');
-const history = new Navigation.HTML5HistoryManager();
 const state = JSON.parse(document.getElementById('state').value);
 
-makeApp({ element, state, history }).start();
+makeApp({ element, state }).start();

--- a/dev/browser-app/index.js
+++ b/dev/browser-app/index.js
@@ -1,4 +1,5 @@
 import 'whatwg-fetch';
+import Navigation from 'navigation';
 import { makeApp } from '../../site/client';
 
 // Hot reloading when state changes
@@ -14,6 +15,7 @@ const handleErrors = response => {
 };
 
 fetch('/state.json').then(handleErrors).then(r => r.json()).then(state => {
-  const app = makeApp({ element, state });
+  const history = new Navigation.HTML5HistoryManager();
+  const app = makeApp({ element, state, history });
   app.start();
 });

--- a/dev/browser-app/index.js
+++ b/dev/browser-app/index.js
@@ -1,5 +1,4 @@
 import 'whatwg-fetch';
-import Navigation from 'navigation';
 import { makeApp } from '../../site/client';
 
 // Hot reloading when state changes
@@ -15,7 +14,6 @@ const handleErrors = response => {
 };
 
 fetch('/state.json').then(handleErrors).then(r => r.json()).then(state => {
-  const history = new Navigation.HTML5HistoryManager();
-  const app = makeApp({ element, state, history });
+  const app = makeApp({ element, state });
   app.start();
 });

--- a/site/client/index.js
+++ b/site/client/index.js
@@ -1,13 +1,14 @@
 import ReactDOM from 'react-dom';
-import Navigation from 'navigation';
+import { HTML5HistoryManager, StateNavigator } from 'navigation';
 
 import makeRoutes from '../../site/routes';
 
 const TITLE_SUFFIX = 'Red Badger';
 
-export function makeApp({ element, state, history }) {
+export function makeApp({ element, state }) {
   const routes = makeRoutes();
-  const stateNavigator = new Navigation.StateNavigator(
+  const history = new HTML5HistoryManager();
+  const stateNavigator = new StateNavigator(
     routes,
     history
   );


### PR DESCRIPTION
### Motivation

We want the URLs to look the same in dev as they do in dev-static. So, instead of using Hash History in dev and HTML5 History in dev-static, we want to use HTML5 History in both.

### Test plan

Check the URLs in dev don't contain a Hash

### Pre-merge checklist

_Not applicable_

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
