### PR TITLE
Changes node version to 4.3.0 and adds caching for Yarn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,21 @@
 machine:
   node:
-    version: 4.3.1
+    version: 4.3.0
   environment:
+    YARN_VERSION: 0.17.8
+    PATH: "${PATH}:${HOME}/.yarn/bin"
     ENVIRONMENT_NAME: staging
 
 dependencies:
+  pre:
+    - |
+      if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+      fi
+  cache_directories:
+    - ~/.yarn
+    - ~/.yarn-cache
   override:
-    - npm i -g yarn
     - yarn
     - cd website-next && yarn
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   node:
     version: 4.3.0
   environment:
-    YARN_VERSION: 0.17.8
+    YARN_VERSION: 0.18.0
     PATH: "${PATH}:${HOME}/.yarn/bin"
     ENVIRONMENT_NAME: staging
 


### PR DESCRIPTION
### Motivation
CircleCI is having some issues with caching node v4.3.1. Since v4.3.0 is preinstalled on their Ubuntu / Debian images, we can downgrade to v4.3.0 and save 3 minutes (also some builds were failing due to downloads failing).

Relevant list of supported versions: https://circleci.com/docs/build-image-trusty/#nodejs

We can also start caching Yarn to strip another 1 - 2 minutes off build time.

Relevant instructions to install Yarn: https://circleci.com/docs/install-and-use-yarn/
