### PR TITLE
Adding cacheability on the routes

### DIFF
--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -4,6 +4,7 @@ type RouteDefinition = {|
   title: string | (props: Object) => string,
   key: string,
   route: string,
+  cacheable: boolean,
   stateToProps?: (state: Object, slug?: string) => any,
   gen?: (state: Object) => Array<string>
 |}
@@ -13,23 +14,27 @@ export const routeDefinitions : Array<RouteDefinition> = [
     title: 'Home',
     key: 'homePage',
     route: '',
+    cacheable: true,
     stateToProps: state => ({ featuredBlogPosts: state.featuredBlogPosts }),
   },
   {
     title: 'What we do',
     key: 'whatWeDoPage',
     route: 'what-we-do',
+    cacheable: true,
   },
   {
     title: 'Join us',
     key: 'joinUs',
     route: 'about-us/join-us',
+    cacheable: false,
     stateToProps: ({ jobs }) => ({ jobs }),
   },
   {
     title: ({ job }) => job.title,
     key: 'job',
     route: 'about-us/join-us/{slug}',
+    cacheable: false,
     stateToProps: (state, slug) => ({ job: state.job[slug] }),
     gen: state => Object.keys(state.job || {}),
   },
@@ -37,15 +42,18 @@ export const routeDefinitions : Array<RouteDefinition> = [
     title: 'Not found',
     key: 'notFoundPage',
     route: '404',
+    cacheable: true,
   },
   {
     title: 'Server error',
     key: 'serverErrorPage',
     route: '50x',
+    cacheable: true,
   },
   {
     title: 'Lost connection',
     key: 'offlinePage',
     route: 'offline',
+    cacheable: true,
   },
 ];

--- a/site/sw.js
+++ b/site/sw.js
@@ -8,7 +8,10 @@ const OFFLINE_URL = 'offline';
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => {
-      const routesToCache = routeDefinitions.map(def => def.route);
+      const routesToCache = routeDefinitions
+      .filter(def => {
+        return {}.hasOwnProperty.call(def, 'cacheable') && def.cacheable;
+      }).map(def => def.route);
       return cache.addAll(routesToCache);
     })
   );


### PR DESCRIPTION
![giphy 3](https://cloud.githubusercontent.com/assets/487468/21139549/51f3708e-c12b-11e6-8334-2d4142927998.gif)

### Motivation

- https://github.com/redbadger/website-honestly/issues/231

Enabling cacheability on routes. Removing `join-us` routes from being cached by service worker since those are mostly dynamic routes. We could bring them back once we figure out the best solution.

### Test plan

- Deploy to staging. Check that service worker is working fine and there are no warnings in the console.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved