### PR TITLE
Removing prefetching of pages with service worker

### DIFF
--- a/site/sw.js
+++ b/site/sw.js
@@ -1,18 +1,7 @@
 /* disable eslint */
 
-import { routeDefinitions } from './routes/definitions';
-
 const CACHE_NAME = 'v1';
 const OFFLINE_URL = 'offline';
-
-self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => {
-      const routesToCache = routeDefinitions.map(def => def.route);
-      return cache.addAll(routesToCache);
-    })
-  );
-});
 
 self.addEventListener('fetch', event => {
   const { url } = event.request;


### PR DESCRIPTION
### Motivation

- https://github.com/redbadger/website-honestly/issues/231

Removing prefetching of routes on Service Worker initialization. Only cache pages as we browse them.

### Test plan

- Deploy to staging. Check that SW has successfully initialised and there are no errors.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

