### PR TITLE
Route Generation Improvements

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -18,9 +18,9 @@ export function makeApp({ element, state }) {
   }
 
   routes.forEach(route => {
-    const render = ({ slug }) => {
+    const render = params => {
       window.scrollTo(0, 0);
-      const props = route.stateToProps && route.stateToProps(state, slug);
+      const props = route.stateToProps && route.stateToProps(state, params);
       const pageTitle = typeof route.title === 'function' ? route.title(props) : route.title;
       const title = `${pageTitle} | ${TITLE_SUFFIX}`;
       stateNavigator.stateContext.title = title;

--- a/site/compiler/asset-paths.js
+++ b/site/compiler/asset-paths.js
@@ -1,8 +1,7 @@
 import assetsDigest from './client-digest';
-import { fullPath } from '../routes';
 
 function filePath(path) {
-  return '/' + fullPath(path);
+  return `${process.env.URL_BASENAME || ''}/${path}`;
 }
 
 const bundleName = assetsDigest.metadata.bundleName;

--- a/site/compiler/asset-paths.js
+++ b/site/compiler/asset-paths.js
@@ -1,7 +1,7 @@
 import assetsDigest from './client-digest';
 
 function filePath(path) {
-  return `${process.env.URL_BASENAME || ''}/${path}`;
+  return `/${process.env.URL_BASENAME || ''}${path}`;
 }
 
 const bundleName = assetsDigest.metadata.bundleName;

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -58,7 +58,7 @@ export function compileRoutes(siteRoutes, state) {
   );
 
   const compile = route => {
-    const path = route.filePath;
+    const path = (process.env.URL_BASENAME || '') + route.filePath;
     const props = route.stateToProps && route.stateToProps(state, route.slug);
 
     const title = `${route.title} | ${TITLE_SUFFIX}`;

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -54,7 +54,7 @@ export function compileRoutes(siteRoutes, state) {
   */
   const stateNavigator = new Navigation.StateNavigator(
     siteRoutes,
-    new Navigation.HTML5HistoryManager(process.env.URL_BASENAME)
+    new Navigation.HTML5HistoryManager((process.env.URL_BASENAME || '').substring(1))
   );
 
   const compile = route => {

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -25,11 +25,15 @@ const titleFor = (def, props) => {
 
 const routeFilePath = path => (path === '' ? `${path}index.html` : `${path}/index.html`);
 
+const filePathFor = (stateNavigator, key, params) => (
+  routeFilePath(stateNavigator.getNavigationLink(key, params).substring(1))
+);
+
 export const expandRoutes = (routeDefs, state, stateNavigator) => {
   const staticRoutes = routeDefs.filter(def => !def.gen).map(def => ({
     ...def,
     title: titleFor(def, def.stateToProps && def.stateToProps(state)),
-    filePath: routeFilePath(stateNavigator.getNavigationLink(def.key).substring(1)),
+    filePath: filePathFor(stateNavigator, def.key),
     props: def.stateToProps && def.stateToProps(state),
   }));
 
@@ -37,7 +41,7 @@ export const expandRoutes = (routeDefs, state, stateNavigator) => {
     return def.gen(state).map(params => ({
       ...def,
       title: titleFor(def, def.stateToProps && def.stateToProps(state, params)),
-      filePath: routeFilePath(stateNavigator.getNavigationLink(def.key, params).substring(1)),
+      filePath: filePathFor(stateNavigator, def.key, params),
       props: def.stateToProps && def.stateToProps(state, params),
     }));
   });

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -23,10 +23,13 @@ const titleFor = (def, props) => {
   Expanded: /, /about-us/join-us/software-engineer etc.
 */
 
+const routeFilePath = path => (path === '' ? `${path}index.html` : `${path}/index.html`);
+
 export const expandRoutes = (routeDefs, state, stateNavigator) => {
   const staticRoutes = routeDefs.filter(def => !def.gen).map(def => ({
     ...def,
     title: titleFor(def, def.stateToProps && def.stateToProps(state)),
+    filePath: routeFilePath(stateNavigator.getNavigationLink(def.key).substring(1)),
     props: def.stateToProps && def.stateToProps(state),
   }));
 
@@ -34,8 +37,7 @@ export const expandRoutes = (routeDefs, state, stateNavigator) => {
     return def.gen(state).map(params => ({
       ...def,
       title: titleFor(def, def.stateToProps && def.stateToProps(state, params)),
-      route: stateNavigator.getNavigationLink(def.key, params),
-      filePath: def.filePath.replace('{slug}', params.slug),
+      filePath: routeFilePath(stateNavigator.getNavigationLink(def.key, params).substring(1)),
       props: def.stateToProps && def.stateToProps(state, params),
     }));
   });
@@ -52,7 +54,7 @@ export function compileRoutes(siteRoutes, state) {
   */
   const stateNavigator = new Navigation.StateNavigator(
     siteRoutes,
-    new Navigation.HTML5HistoryManager()
+    new Navigation.HTML5HistoryManager(process.env.URL_BASENAME)
   );
 
   const compile = route => {

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -23,7 +23,7 @@ const titleFor = (def, props) => {
   Expanded: /, /about-us/join-us/software-engineer etc.
 */
 
-export const expandRoutes = (routeDefs, state) => {
+export const expandRoutes = (routeDefs, state, stateNavigator) => {
   const staticRoutes = routeDefs.filter(def => !def.gen).map(def => ({
     ...def,
     title: titleFor(def, def.stateToProps && def.stateToProps(state)),
@@ -31,13 +31,12 @@ export const expandRoutes = (routeDefs, state) => {
   }));
 
   const dynamicRoutes = routeDefs.filter(def => !!def.gen).map(def => {
-    return def.gen(state).map(slug => ({
+    return def.gen(state).map(params => ({
       ...def,
-      slug,
-      title: titleFor(def, def.stateToProps && def.stateToProps(state, slug)),
-      route: def.route.replace('{slug}', slug),
-      filePath: def.filePath.replace('{slug}', slug),
-      props: def.stateToProps && def.stateToProps(state, slug),
+      title: titleFor(def, def.stateToProps && def.stateToProps(state, params)),
+      route: stateNavigator.getNavigationLink(def.key, params),
+      filePath: def.filePath.replace('{slug}', params.slug),
+      props: def.stateToProps && def.stateToProps(state, params),
     }));
   });
 
@@ -74,7 +73,7 @@ export function compileRoutes(siteRoutes, state) {
     return { body, path };
   };
 
-  return expandRoutes(siteRoutes, state).map(compile);
+  return expandRoutes(siteRoutes, state, stateNavigator).map(compile);
 }
 
 export function compileSite(state) {

--- a/site/compiler/test.js
+++ b/site/compiler/test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StateNavigator } from 'navigation';
 import { compileSite, compileRoutes, expandRoutes } from '.';
 
 describe('site/compiler', () => {
@@ -25,12 +26,12 @@ describe('site/compiler', () => {
         route: 'dynamic/{slug}',
         filePath: 'dynamic/{slug}/index.html',
         component: () => <A />,
-        gen: ({ dynamic }) => Object.keys(dynamic),
-        stateToProps: ({ dynamic }, slug) => dynamic[slug],
+        gen: ({ dynamic }) => Object.keys(dynamic).map(slug => ({ slug })),
+        stateToProps: ({ dynamic }, { slug }) => dynamic[slug],
       },
     ];
 
-    const expanded = expandRoutes(routes, { dynamic: { A: 'A!', B: 'B!' } });
+    const expanded = expandRoutes(routes, { dynamic: { A: 'A!', B: 'B!' } }, new StateNavigator(routes));
 
     it('leaves static routes as-is', () => {
       expect(expanded[0].title).to.equal(routes[0].title);
@@ -40,11 +41,11 @@ describe('site/compiler', () => {
 
     it('expands dynamic routes', () => {
       expect(expanded[1].title).to.equal('Dynamic Page A!');
-      expect(expanded[1].route).to.equal('dynamic/A');
+      expect(expanded[1].route).to.equal('/dynamic/A');
       expect(expanded[1].filePath).to.equal('dynamic/A/index.html');
 
       expect(expanded[2].title).to.equal('Dynamic Page B!');
-      expect(expanded[2].route).to.equal('dynamic/B');
+      expect(expanded[2].route).to.equal('/dynamic/B');
       expect(expanded[2].filePath).to.equal('dynamic/B/index.html');
     });
 

--- a/site/compiler/test.js
+++ b/site/compiler/test.js
@@ -17,14 +17,12 @@ describe('site/compiler', () => {
         title: 'Home',
         key: 'home',
         route: '',
-        filePath: 'index.html',
         component: () => <A />,
       },
       {
         title: props => `Dynamic Page ${props}`,
         key: 'dynamic',
         route: 'dynamic/{slug}',
-        filePath: 'dynamic/{slug}/index.html',
         component: () => <A />,
         gen: ({ dynamic }) => Object.keys(dynamic).map(slug => ({ slug })),
         stateToProps: ({ dynamic }, { slug }) => dynamic[slug],
@@ -37,15 +35,14 @@ describe('site/compiler', () => {
       expect(expanded[0].title).to.equal(routes[0].title);
       expect(expanded[0].key).to.equal(routes[0].key);
       expect(expanded[0].component).to.equal(routes[0].component);
+      expect(expanded[0].filePath).to.equal('index.html');
     });
 
     it('expands dynamic routes', () => {
       expect(expanded[1].title).to.equal('Dynamic Page A!');
-      expect(expanded[1].route).to.equal('/dynamic/A');
       expect(expanded[1].filePath).to.equal('dynamic/A/index.html');
 
       expect(expanded[2].title).to.equal('Dynamic Page B!');
-      expect(expanded[2].route).to.equal('/dynamic/B');
       expect(expanded[2].filePath).to.equal('dynamic/B/index.html');
     });
 

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -4,8 +4,8 @@ type RouteDefinition = {|
   title: string | (props: Object) => string,
   key: string,
   route: string,
-  stateToProps?: (state: Object, slug?: string) => any,
-  gen?: (state: Object) => Array<string>
+  stateToProps?: (state: Object, params?: Object) => any,
+  gen?: (state: Object) => Array<Object>
 |}
 
 export const routeDefinitions : Array<RouteDefinition> = [
@@ -30,8 +30,8 @@ export const routeDefinitions : Array<RouteDefinition> = [
     title: ({ job }) => job.title,
     key: 'job',
     route: 'about-us/join-us/{slug}',
-    stateToProps: (state, slug) => ({ job: state.job[slug] }),
-    gen: state => Object.keys(state.job || {}),
+    stateToProps: (state, params = {}) => ({ job: state.job[params.slug] }),
+    gen: state => state.jobs.map(({ slug }) => ({ slug })),
   },
   {
     title: 'Not found',

--- a/site/routes/index.js
+++ b/site/routes/index.js
@@ -11,31 +11,6 @@ import OfflinePage from '../pages/offline';
 import JoinUsPage from '../../website-next/src/shared/containers/join-us';
 import JobPage from '../../website-next/src/shared/containers/job';
 
-export function fullPath(route) {
-  const routePrefix = process.env.URL_BASENAME || '';
-  return `${routePrefix}${route}`;
-}
-
-function routeFilePath(path) {
-  switch (path) {
-    case '':
-      return `${fullPath(path)}index.html`;
-
-    default:
-      return `${fullPath(path)}/index.html`;
-  }
-}
-
-function prefixRoutes(rs) {
-  return rs.map(route => {
-    const fullRoute = fullPath(route.route);
-    return Object.assign({}, route, {
-      route: fullRoute,
-      filePath: routeFilePath(route.route),
-    });
-  });
-}
-
 const componentMap = {
   homePage: HomePage,
   whatWeDoPage: WhatWeDoPage,
@@ -47,12 +22,12 @@ const componentMap = {
 };
 
 export default function routes() {
-  return prefixRoutes(routeDefinitions.map(
+  return routeDefinitions.map(
     route => ({
       ...route,
       component: (routerProps, props) => {
         const Component = componentMap[route.key];
         return (<L {...routerProps}><Component {...props} /></L>);
       },
-    })));
+    }));
 }

--- a/webpack.dev.static.config.js
+++ b/webpack.dev.static.config.js
@@ -14,16 +14,6 @@ const devStaticConfig = webpackMerge(baseConfig, {
   externals: [
     './client-digest',
   ],
-  plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        unused: true,
-        dead_code: true,
-        warnings: false,
-        drop_debugger: true,
-      },
-    }),
-  ],
 });
 
 const clientConfig = webpackMerge(baseConfig, {


### PR DESCRIPTION
### Motivation

We should be using @grahammendick (AKA Señor Router)'s library to generate routes for us, not manually doing string replacement. This PR adds that, and in turn, enables support for `/urls/with/{multiple}/{params}`.

### Test plan

The core of this is unit testable. But we should double check `dev-static`, `dev` and `commit-site` deployments all work as expected.

### Pre-merge checklist

- [x] Documentation
- [x] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
