### PR TITLE
Insert 500 status code to lambda callback error message

### DIFF
--- a/services/contact_us.js
+++ b/services/contact_us.js
@@ -3,7 +3,7 @@ import aws from 'aws-sdk'; // eslint-disable-line import/no-unresolved, import/n
 import { validateAndSendEmail } from './ses';
 
 
-export default function doContactUs(event, context, cb) {
+export default function doContactUs(event, _, cb) {
   const contactUsEmailTo = process.env.CONTACT_US_EMAIL_TO;
 
   if (!contactUsEmailTo) {

--- a/services/contact_us.js
+++ b/services/contact_us.js
@@ -3,7 +3,7 @@ import aws from 'aws-sdk'; // eslint-disable-line import/no-unresolved, import/n
 import { validateAndSendEmail } from './ses';
 
 
-export default function doContactUs(event, cb) {
+export default function doContactUs(event, context, cb) {
   const contactUsEmailTo = process.env.CONTACT_US_EMAIL_TO;
 
   if (!contactUsEmailTo) {

--- a/services/index.js
+++ b/services/index.js
@@ -11,38 +11,30 @@ const cbWithErrorHandling = cb => (e, body) => {
   return cb(null, body);
 };
 
+const errorHandlerWrapper = (f, event, context, cb) => {
+  try {
+    f(event, context, cbWithErrorHandling(cb));
+  } catch (e) {
+    cbWithErrorHandling(cb)(e);
+  }
+};
+
 export function publish(event, context, cb) {
   if (event.query && event.query.auth_token !== process.env.PRIVATE_LAMBDA_API_KEY) {
     return cb(new Error('[403] Forbidden'));
   }
 
-  try {
-    doPublish(cbWithErrorHandling(cb));
-  } catch (e) {
-    cbWithErrorHandling(cb)(e);
-  }
+  errorHandlerWrapper(doPublish, event, context, cb);
 }
 
 export function contactUs(event, context, cb) {
-  try {
-    doContactUs(event, cbWithErrorHandling(cb));
-  } catch (e) {
-    cbWithErrorHandling(cb)(e);
-  }
+  errorHandlerWrapper(doContactUs, event, context, cb);
 }
 
 export function signUp(event, context, cb) {
-  try {
-    doSignUp(event, cbWithErrorHandling(cb));
-  } catch (e) {
-    cbWithErrorHandling(cb)(e);
-  }
+  errorHandlerWrapper(doSignUp, event, context, cb);
 }
 
 export function updateUser(event, context, cb) {
-  try {
-    doUpdateUser(event, cbWithErrorHandling(cb));
-  } catch (e) {
-    cbWithErrorHandling(cb)(e);
-  }
+  errorHandlerWrapper(doUpdateUser, event, context, cb);
 }

--- a/services/index.js
+++ b/services/index.js
@@ -11,7 +11,7 @@ const cbWithErrorHandling = cb => (e, body) => {
   return cb(null, body);
 };
 
-const errorHandlerWrapper = (f, event, context, cb) => {
+const errorHandlerWrapper = f => (event, context, cb) => {
   try {
     f(event, context, cbWithErrorHandling(cb));
   } catch (e) {
@@ -24,17 +24,11 @@ export function publish(event, context, cb) {
     return cb(new Error('[403] Forbidden'));
   }
 
-  errorHandlerWrapper(doPublish, event, context, cb);
+  errorHandlerWrapper(doPublish)(event, context, cb);
 }
 
-export function contactUs(event, context, cb) {
-  errorHandlerWrapper(doContactUs, event, context, cb);
-}
+export const contactUs = errorHandlerWrapper(doContactUs);
 
-export function signUp(event, context, cb) {
-  errorHandlerWrapper(doSignUp, event, context, cb);
-}
+export const signUp = errorHandlerWrapper(doSignUp);
 
-export function updateUser(event, context, cb) {
-  errorHandlerWrapper(doUpdateUser, event, context, cb);
-}
+export const updateUser = errorHandlerWrapper(doUpdateUser);

--- a/services/index.js
+++ b/services/index.js
@@ -3,38 +3,46 @@ import doContactUs from './contact_us';
 import doSignUp from './mailchimp/sign-up/index';
 import doUpdateUser from './mailchimp/update-user/index';
 
+const cbWithErrorHandling = cb => (e, body) => {
+  if (e) {
+    e.message = `[500] ${e.message}`; // eslint-disable-line no-param-reassign
+    return cb(e);
+  }
+  return cb(null, body);
+};
+
 export function publish(event, context, cb) {
   if (event.query && event.query.auth_token !== process.env.PRIVATE_LAMBDA_API_KEY) {
     return cb(new Error('[403] Forbidden'));
   }
 
   try {
-    doPublish(cb);
+    doPublish(cbWithErrorHandling(cb));
   } catch (e) {
-    cb(e);
+    cbWithErrorHandling(cb)(e);
   }
 }
 
 export function contactUs(event, context, cb) {
   try {
-    doContactUs(event, cb);
+    doContactUs(event, cbWithErrorHandling(cb));
   } catch (e) {
-    cb(e);
+    cbWithErrorHandling(cb)(e);
   }
 }
 
 export function signUp(event, context, cb) {
   try {
-    doSignUp(event, cb);
+    doSignUp(event, cbWithErrorHandling(cb));
   } catch (e) {
-    cb(e);
+    cbWithErrorHandling(cb)(e);
   }
 }
 
 export function updateUser(event, context, cb) {
   try {
-    doUpdateUser(event, cb);
+    doUpdateUser(event, cbWithErrorHandling(cb));
   } catch (e) {
-    cb(e);
+    cbWithErrorHandling(cb)(e);
   }
 }

--- a/services/mailchimp/sign-up/index.js
+++ b/services/mailchimp/sign-up/index.js
@@ -3,7 +3,7 @@
 import { mailchimpApi, formatFormInput, formatSignUpResponse } from '../utilities';
 
 
-export default function signUp(event, cb) {
+export default function signUp(event, context, cb) {
   const mailingListId = process.env.MAILING_LIST_ID;
   const body = formatFormInput(event);
   return mailchimpApi(

--- a/services/mailchimp/sign-up/index.js
+++ b/services/mailchimp/sign-up/index.js
@@ -3,7 +3,7 @@
 import { mailchimpApi, formatFormInput, formatSignUpResponse } from '../utilities';
 
 
-export default function signUp(event, context, cb) {
+export default function signUp(event, _, cb) {
   const mailingListId = process.env.MAILING_LIST_ID;
   const body = formatFormInput(event);
   return mailchimpApi(

--- a/services/mailchimp/update-user/index.js
+++ b/services/mailchimp/update-user/index.js
@@ -1,7 +1,7 @@
 import md5 from 'md5';
 import { mailchimpApi, formatUpdateResponse, formatFormInput } from '../utilities';
 
-export default function doUpdateUser(event, context, cb) {
+export default function doUpdateUser(event, _, cb) {
   const mailingListId = process.env.MAILING_LIST_ID;
   const body = formatFormInput(event, true);
   const emailAddress = body.email_address.toLowerCase();

--- a/services/mailchimp/update-user/index.js
+++ b/services/mailchimp/update-user/index.js
@@ -1,7 +1,7 @@
 import md5 from 'md5';
 import { mailchimpApi, formatUpdateResponse, formatFormInput } from '../utilities';
 
-export default function doUpdateUser(event, cb) {
+export default function doUpdateUser(event, context, cb) {
   const mailingListId = process.env.MAILING_LIST_ID;
   const body = formatFormInput(event, true);
   const emailAddress = body.email_address.toLowerCase();
@@ -19,4 +19,3 @@ export default function doUpdateUser(event, cb) {
       cb(err);
     });
 }
-

--- a/services/publish.js
+++ b/services/publish.js
@@ -10,7 +10,7 @@ if (!bucketName) {
   throw new Error('bucketName environment variable not set!');
 }
 
-export default function doPublish(cb) {
+export default function doPublish(event, context, cb) {
   console.log(`Publishing to S3 bucket ${bucketName}`);
   getSiteState()
     .then(compileSite)

--- a/services/publish.js
+++ b/services/publish.js
@@ -10,7 +10,7 @@ if (!bucketName) {
   throw new Error('bucketName environment variable not set!');
 }
 
-export default function doPublish(event, context, cb) {
+export default function doPublish(_, __, cb) {
   console.log(`Publishing to S3 bucket ${bucketName}`);
   getSiteState()
     .then(compileSite)

--- a/site/client/index.js
+++ b/site/client/index.js
@@ -18,9 +18,9 @@ export function makeApp({ element, state }) {
   }
 
   routes.forEach(route => {
-    const render = ({ slug }) => {
+    const render = params => {
       window.scrollTo(0, 0);
-      const props = route.stateToProps && route.stateToProps(state, slug);
+      const props = route.stateToProps && route.stateToProps(state, params);
       const pageTitle = typeof route.title === 'function' ? route.title(props) : route.title;
       const title = `${pageTitle} | ${TITLE_SUFFIX}`;
       stateNavigator.stateContext.title = title;

--- a/site/compiler/asset-paths.js
+++ b/site/compiler/asset-paths.js
@@ -1,8 +1,7 @@
 import assetsDigest from './client-digest';
-import { fullPath } from '../routes';
 
 function filePath(path) {
-  return '/' + fullPath(path);
+  return `/${process.env.URL_BASENAME || ''}${path}`;
 }
 
 const bundleName = assetsDigest.metadata.bundleName;

--- a/site/compiler/test.js
+++ b/site/compiler/test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StateNavigator } from 'navigation';
 import { compileSite, compileRoutes, expandRoutes } from '.';
 
 describe('site/compiler', () => {
@@ -16,35 +17,32 @@ describe('site/compiler', () => {
         title: 'Home',
         key: 'home',
         route: '',
-        filePath: 'index.html',
         component: () => <A />,
       },
       {
         title: props => `Dynamic Page ${props}`,
         key: 'dynamic',
         route: 'dynamic/{slug}',
-        filePath: 'dynamic/{slug}/index.html',
         component: () => <A />,
-        gen: ({ dynamic }) => Object.keys(dynamic),
-        stateToProps: ({ dynamic }, slug) => dynamic[slug],
+        gen: ({ dynamic }) => Object.keys(dynamic).map(slug => ({ slug })),
+        stateToProps: ({ dynamic }, { slug }) => dynamic[slug],
       },
     ];
 
-    const expanded = expandRoutes(routes, { dynamic: { A: 'A!', B: 'B!' } });
+    const expanded = expandRoutes(routes, { dynamic: { A: 'A!', B: 'B!' } }, new StateNavigator(routes));
 
     it('leaves static routes as-is', () => {
       expect(expanded[0].title).to.equal(routes[0].title);
       expect(expanded[0].key).to.equal(routes[0].key);
       expect(expanded[0].component).to.equal(routes[0].component);
+      expect(expanded[0].filePath).to.equal('index.html');
     });
 
     it('expands dynamic routes', () => {
       expect(expanded[1].title).to.equal('Dynamic Page A!');
-      expect(expanded[1].route).to.equal('dynamic/A');
       expect(expanded[1].filePath).to.equal('dynamic/A/index.html');
 
       expect(expanded[2].title).to.equal('Dynamic Page B!');
-      expect(expanded[2].route).to.equal('dynamic/B');
       expect(expanded[2].filePath).to.equal('dynamic/B/index.html');
     });
 

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -4,8 +4,8 @@ type RouteDefinition = {|
   title: string | (props: Object) => string,
   key: string,
   route: string,
-  stateToProps?: (state: Object, slug?: string) => any,
-  gen?: (state: Object) => Array<string>
+  stateToProps?: (state: Object, params?: Object) => any,
+  gen?: (state: Object) => Array<Object>
 |}
 
 export const routeDefinitions : Array<RouteDefinition> = [
@@ -30,8 +30,8 @@ export const routeDefinitions : Array<RouteDefinition> = [
     title: ({ job }) => job.title,
     key: 'job',
     route: 'about-us/join-us/{slug}',
-    stateToProps: (state, slug) => ({ job: state.job[slug] }),
-    gen: state => Object.keys(state.job || {}),
+    stateToProps: (state, params = {}) => ({ job: state.job[params.slug] }),
+    gen: state => state.jobs.map(({ slug }) => ({ slug })),
   },
   {
     title: 'Not found',

--- a/site/routes/index.js
+++ b/site/routes/index.js
@@ -11,31 +11,6 @@ import OfflinePage from '../pages/offline';
 import JoinUsPage from '../../website-next/src/shared/containers/join-us';
 import JobPage from '../../website-next/src/shared/containers/job';
 
-export function fullPath(route) {
-  const routePrefix = process.env.URL_BASENAME || '';
-  return `${routePrefix}${route}`;
-}
-
-function routeFilePath(path) {
-  switch (path) {
-    case '':
-      return `${fullPath(path)}index.html`;
-
-    default:
-      return `${fullPath(path)}/index.html`;
-  }
-}
-
-function prefixRoutes(rs) {
-  return rs.map(route => {
-    const fullRoute = fullPath(route.route);
-    return Object.assign({}, route, {
-      route: fullRoute,
-      filePath: routeFilePath(route.route),
-    });
-  });
-}
-
 const componentMap = {
   homePage: HomePage,
   whatWeDoPage: WhatWeDoPage,
@@ -47,12 +22,12 @@ const componentMap = {
 };
 
 export default function routes() {
-  return prefixRoutes(routeDefinitions.map(
+  return routeDefinitions.map(
     route => ({
       ...route,
       component: (routerProps, props) => {
         const Component = componentMap[route.key];
         return (<L {...routerProps}><Component {...props} /></L>);
       },
-    })));
+    }));
 }

--- a/webpack.dev.static.config.js
+++ b/webpack.dev.static.config.js
@@ -14,16 +14,6 @@ const devStaticConfig = webpackMerge(baseConfig, {
   externals: [
     './client-digest',
   ],
-  plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        unused: true,
-        dead_code: true,
-        warnings: false,
-        drop_debugger: true,
-      },
-    }),
-  ],
 });
 
 const clientConfig = webpackMerge(baseConfig, {


### PR DESCRIPTION
### Motivation

- Gateway API was returning status code 200 on error throws, causing `curl --fail` to return successfully on `make publish-service-invoke` and not triggering a build fail on circle ci

### Test plan

- `make publish-service-invoke` must return an exit code different than 0 if errors are thrown during publishing

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [x] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing (not applicable)
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

