### PR TITLE
Wrapped anchor in h2 (lost during merge)

### DIFF
--- a/website-next/src/shared/components/event-title/index.js
+++ b/website-next/src/shared/components/event-title/index.js
@@ -3,8 +3,10 @@ import classNames from 'classnames';
 import icons from '../icons/style.css';
 import styles from '../events-list/style.css';
 import { h2 } from '../typography/style.css';
+import Link from '../../../../../site/components/link';
 
 const EventTitle = ({
+  eventLink,
   eventTitle,
 }) => (
   <h2
@@ -13,14 +15,17 @@ const EventTitle = ({
       [h2]: true,
     })}
   >
-    <span>
-      {eventTitle}
-    </span>
+    <Link to="event" navigationData={eventLink} className={styles.eventTitleLink}>
+      <span>
+        {eventTitle}
+      </span>
+    </Link>
   </h2>
 );
 
 EventTitle.propTypes = {
   eventTitle: PropTypes.string.isRequired,
+  eventLink: PropTypes.object.isRequired,
 };
 
 export default EventTitle;

--- a/website-next/src/shared/components/events-news-list-entry/index.js
+++ b/website-next/src/shared/components/events-news-list-entry/index.js
@@ -57,11 +57,10 @@ const EventsNewsListEntry = ({
               <Cell size={8} key='event_description'
                 breakOn="mobileS"
               >
-              <Link to="event" navigationData={eventLink}>
-                <EventTitle
-                  eventTitle={title}
-                />
-              </Link>
+              <EventTitle
+                eventLink={eventLink}
+                eventTitle={title}
+              />
               <div className={styles.eventDescription}>
                 {strapline}
               </div>


### PR DESCRIPTION
### Motivation

Fixes #270

### Test plan

Check the red underlines appear when you hover on a link in the Events list

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

