### PR TITLE
Closed Small Navigation Menu when About Us is clicked

### DIFF
--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -62,11 +62,11 @@ export default class SmallScreenNav extends React.Component {
             <nav className={styles.smallScreenNavContainer} role="navigation">
               <ul role="listbox" className={styles.smallScreenNav}>
                 <li><Link tabIndex={navTabIndex} to="homePage" navigating={this.closeMenu}>Home</Link></li>
-                <li><Link tabIndex={navTabIndex} to="aboutUsPage" >About us</Link></li>
+                <li><Link tabIndex={navTabIndex} to="aboutUsPage" navigating={this.closeMenu}>About us</Link></li>
                 <li><Link tabIndex={navTabIndex} to="whatWeDoPage" navigating={this.closeMenu}>What we do</Link></li>
                 <li><a tabIndex={navTabIndex} href="/blog/">Blog</a></li>
                 <li><Link tabIndex={navTabIndex} to="events" navigating={this.closeMenu}>Events</Link></li>
-                <li><a tabIndex={navTabIndex} href="/about-us/join-us/">Jobs</a></li>
+                <li><Link tabIndex={navTabIndex} to="joinUs" navigating={this.closeMenu}>Jobs</Link></li>
                 <li><a tabIndex={navTabIndex} href="/about-us/contact-us/">Contact us</a></li>
               </ul>
             </nav>


### PR DESCRIPTION
### Motivation

The Small Navigation Menu should close when About Us is clicked so that it behaves like the other links.

### Test plan

Check that the Small Navigation Menu closes when the About Us is clicked

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
