### PR TITLE
Release Management

### DIFF
--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -35,6 +35,7 @@ deployMaster() {
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/sw.js
   make services-deploy
   make publish-service-invoke
+  ./bin/register-github-release.js $1
   echo Done!
 }
 

--- a/bin/register-github-release.js
+++ b/bin/register-github-release.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fetch = require('node-fetch');
+
+if (process.env.argv[2] !== 'live') {
+  console.log('Skipping release tracking for non-production environment.');
+}
+
+const env = key => {
+  const value = process.env[key];
+  if (value) { return value; }
+  console.error(`env var ${key} not set`);
+  process.exit(1);
+};
+
+const gitHubUsername = env('GITHUB_USERNAME');
+const gitHubToken = env('GITHUB_TOKEN');
+
+const creds = `${gitHubUsername}:${gitHubToken}`;
+const auth = new Buffer(creds).toString('base64');
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  Authorization: `Basic ${auth}`,
+};
+
+const deploymentsUrl =
+  'https://api.github.com/repos/redbadger/website-honestly/releases';
+
+const assertStatusOK = response => {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  }
+  return response.json().then(json => {
+    console.error(`Expected HTTP status to be OK. Was ${response.status} ${response.statusText}`);
+    console.error(json);
+    process.exit(1);
+  });
+};
+
+const registerRelease = () =>
+  fetch(deploymentsUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      name: 'Deployment @ ' + new Date().toString().split(' GMT')[0],
+      tag_name: Date.now().toString(),
+    }),
+  });
+
+const parseJson = blob => blob.json();
+
+registerRelease()
+  .then(assertStatusOK)
+  .then(parseJson)
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Motivation

Automatically create releases when running website honestly deploy. This means we don't have to do this manually to keep track of which code is deployed, and which is pending release.

It uses the Badgerbot GitHub access token. Configured in CircleCI

### Test plan

Production deployments should create a release (I've tested this already)

### Pre-merge checklist

**Not applicable**

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
