### PR TITLE
Moving typography.com font link to the head of the page

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -42,6 +42,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-16654919-1', 'auto');
 ga('send', 'pageview');
     </script><% } %>
+    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </head>
   <body>
     <div class="js-app">
@@ -49,6 +50,5 @@ ga('send', 'pageview');
     </div>
     <input id="state" type="hidden" value="<%= typeof state !== 'undefined' ? state : '{}' %>">
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
-    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7848772/css/fonts.css">
   </body>
 </html>


### PR DESCRIPTION
Fix for #228

### Motivation

- #228 

### Test plan

- Empty cache and load the site. Check that main title font is not blinking when page is loading. Chrome was mainly affected by that - refer to the main live site for demonstration.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
