### PR TITLE
add babel polyfill to webpack dev configurations

### DIFF
--- a/webpack.dev.browser.config.js
+++ b/webpack.dev.browser.config.js
@@ -6,9 +6,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 process.env.BABEL_ENV = 'typecheck';
 
 const devAppConfig = webpackMerge(baseConfig, {
-  entry: {
-    '/dev-app': './dev/browser-app/index.js',
-  },
+  entry: ['babel-polyfill', './dev/browser-app/index.js'],
   target: 'web',
   plugins: [
     new HtmlWebpackPlugin({

--- a/webpack.dev.static.config.js
+++ b/webpack.dev.static.config.js
@@ -6,9 +6,7 @@ const AssetsPlugin = require('assets-webpack-plugin');
 process.env.BABEL_ENV = 'typecheck';
 
 const devStaticConfig = webpackMerge(baseConfig, {
-  entry: {
-    'dev-static': './dev/static/index.js',
-  },
+  entry: ['babel-polyfill', './dev/static/index.js'],
   output: {
     libraryTarget: 'commonjs',
   },


### PR DESCRIPTION
### Motivation

- Website is not rendering in IE11 on dev environment due to lacking babel polyfill. This fixes that.

### Test plan

- Open browserstack with IE11 browser using your local environment.

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews N/A
  - [ ] Code review
  - [ ] Design review N/A
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
