### PR TITLE
fix icons centring on windows edge

### DIFF
--- a/site/components/case-study/style.css
+++ b/site/components/case-study/style.css
@@ -49,6 +49,7 @@
 
 .caseFigure svg {
   height: 80px;
+  width: 100%;
 }
 
 .logo {


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/302)

Numbers in case studies on homepage are not centred on MS Edge.

### Test plan

- Open the website using different browsers and see if icons are centred on smaller window sizes.

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
