### PR TITLE
remove textarea navigation arrows on ie11

### DIFF
--- a/site/slices/contact-us-slice/form/style.css
+++ b/site/slices/contact-us-slice/form/style.css
@@ -15,6 +15,10 @@
   composes: sansSerif from "../../../css/typography/_fonts.css";
 }
 
+.contactUsForm textarea {
+  overflow: hidden;
+}
+
 .heading {
   max-width: contentMaxWidth;
   composes: fontL from "../../../css/typography/_fonts.css";

--- a/site/slices/contact-us-slice/form/style.css
+++ b/site/slices/contact-us-slice/form/style.css
@@ -15,8 +15,9 @@
   composes: sansSerif from "../../../css/typography/_fonts.css";
 }
 
-.contactUsForm textarea {
-  overflow: hidden;
+/* for ie11 */
+_:-ms-fullscreen, :root .contactUsForm textarea {
+  overflow: auto;
 }
 
 .heading {


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/286)

Contact form on "cain slice" has ugly scroll bar on IE11.

### Test plan

- Open the website on IE11 and see that the textarea hasn't got any arrows anymore

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A/
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [x] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [x] Tester approved
