### PR TITLE
Better Fetch Errors

### DIFF
--- a/site/fetchers/handle-errors.js
+++ b/site/fetchers/handle-errors.js
@@ -1,6 +1,6 @@
 export default response => {
   if (!response.ok) {
-    throw Error(response.statusText);
+    throw Error(`${response.statusText} for request: ${response.url}`);
   }
 
   return response;


### PR DESCRIPTION
Actually log which URL we are attempting to fetch, rather than just the error message. This will help when the publish lambda fails because of key problems, for example.
