### PR TITLE
mobile menu not visible on iOS8 fix

### DIFF
--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -114,7 +114,7 @@
 }
 
 .smallScreenNavComponent {
-  width: 100%;
+  flex: 1;
 }
 
 .triggerContainer {


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/282)

Mobile nav menu is not shown on iOS 8 or earlier

### Test plan

- The error only occurs on production so open the PR deployment on iPhone iOS8.

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
