### PR TITLE
scrollable background context fix

### DIFF
--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -14,16 +14,37 @@ export default class SmallScreenNav extends React.Component {
   }
 
   handleInputChange = event => {
+    this.scrollLock();
     this.setState({
       navOpen: event.target.checked,
     });
   }
 
   closeMenu = () => {
+    this.scrollRelease();
     this.setState({
       navOpen: false,
     });
     return true;
+  }
+
+  scrollLock = () => {
+    this.smallScreenNav.addEventListener('wheel', this.onScrollHandler, false);
+    this.smallScreenNav.addEventListener('touchmove', this.onScrollHandler, false);
+  }
+
+  scrollRelease = () => {
+    this.smallScreenNav.removeEventListener('wheel', this.onScrollHandler, false);
+    this.smallScreenNav.removeEventListener('touchmove', this.onScrollHandler, false);
+  }
+
+  onScrollHandler = e => {
+    e.stopImmediatePropagation();
+    e.preventDefault();
+  }
+
+  componentWillUnmount = () => {
+    this.scrollRelease();
   }
 
   render() {
@@ -31,7 +52,7 @@ export default class SmallScreenNav extends React.Component {
     const navTabIndex = navOpen ? 0 : -1;
 
     return (
-      <div className={styles.smallScreenNavComponent}>
+      <div ref={c => { this.smallScreenNav = c; }} className={styles.smallScreenNavComponent}>
         <div className={styles.triggerContainer}>
           <label
             htmlFor="burger"


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/171)

Open page (background content) shouldn't be scrollable / screen readable when mobile nav is open

### Test plan

- Open the PR deployment in browserstack on mobile to see that you can't scroll when the menu is open. You can also test it on desktop browser when the window size is narrow to see that you can't use your mouse wheel / touchpad to scroll.

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [x] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [ ] Tester approved
