### PR TITLE
Fixed Keyboard Navigation on About Us page

### DIFF
--- a/site/pages/about-us/principles-slice/index.js
+++ b/site/pages/about-us/principles-slice/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import style from './style.css';
 import Principle from './principle';
-import Button from '../../../components/button';
 import Link from '../../../components/link';
 
 export default function Principles() {
@@ -23,8 +22,8 @@ export default function Principles() {
           <Principle number="08" title="Give a monkey’s. Don’t be a jackass." description="We care about what we do and we care about each other. We’re humble. No egos." />
         </ul>
         <div className={style.buttons}>
-          <a href="/about-us/people/"><Button label="Meet our team" background="black" /></a>
-          <Link to="joinUs"><Button label="Join us" background="black" /></Link>
+          <a href="/about-us/people/" className={style.link}>Meet our team</a>
+          <Link to="joinUs" className={style.link}>Join us</Link>
         </div>
       </div>
     </div>

--- a/site/pages/about-us/principles-slice/style.css
+++ b/site/pages/about-us/principles-slice/style.css
@@ -1,5 +1,5 @@
 @value mediumScreen, largeScreen, contentMaxWidth from "../../../css/_sizes.css";
-@value badgerWhite, badgerRed, badgerBlack from "../../../css/_colors.css";
+@value badgerWhite, badgerRed, badgerBlack, scorpian from "../../../css/_colors.css";
 
 .principles {
   background:badgerBlack;
@@ -31,9 +31,14 @@
   padding-bottom: 50px;
 }
 
-.buttons a button{
-  margin-bottom: 20px;
+.link{
+  composes: primaryButton from "../../../css/_links.css";
   margin-right: 20px;
+  margin-bottom: 20px;
+}
+
+.link:hover {
+  background: scorpian;
 }
 
 .principleList {

--- a/site/pages/about-us/timeline-slice/navigator/item/style.css
+++ b/site/pages/about-us/timeline-slice/navigator/item/style.css
@@ -9,7 +9,6 @@
   composes: boldSansSerif from "../../../../../css/typography/_fonts.css";
 	composes: fontXS from "../../../../../css/typography/_fonts.css";
   transition: 0.3s ease-in-out;
-  left: -15px;
   cursor: pointer;
 }
 
@@ -25,11 +24,11 @@
   border: none;
   background: transparent;
   top: -35px;
-  margin-left: -5px;
+  margin-left: -18px;
   text-align: left;
   padding: 0;
   height: 40px;
-  width: 20px;
+  width: 36px;
   overflow: visible;
 }
 
@@ -62,6 +61,7 @@
   bottom: 0px;
   cursor: pointer;
   background-color: #CCC;
+  left: 12px;
  }
 
 .old span,

--- a/site/pages/about-us/timeline-slice/navigator/item/style.css
+++ b/site/pages/about-us/timeline-slice/navigator/item/style.css
@@ -13,7 +13,7 @@
   cursor: pointer;
 }
 
-.active a, 
+.active a,
 .text:hover{
   color: badgerRed;
 }
@@ -37,13 +37,6 @@
 .active span{
   background-color: badgerRed;
 }
-
-.old:focus,
-.active:focus,
-.future:focus{
-  outline: none;
-}
-
 
 .old:hover,
 .active:hover,


### PR DESCRIPTION
### Motivation

Fixes #321

1. Removed the buttons inside the `Meet our team` and `Join us` links because this was causing a double tab to move through each of them
2. Removed `outline:none` from the timeline navigation buttons so it's clear which year is active when tabbing through

### Test plan

Test the keyboard navigation on the about us page

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
