### PR TITLE
fix link to meet our team inconsistency

### DIFF
--- a/site/pages/about-us/principles-slice/index.js
+++ b/site/pages/about-us/principles-slice/index.js
@@ -23,7 +23,7 @@ export default function Principles() {
           <Principle number="08" title="Give a monkey’s. Don’t be a jackass." description="We care about what we do and we care about each other. We’re humble. No egos." />
         </ul>
         <div className={style.buttons}>
-          <a href="/about-us/people/"><Button label="Meet our team" background="black" /></a>
+          <Link to="badgers"><Button label="Meet our team" background="black" /></Link>
           <Link to="joinUs"><Button label="Join us" background="black" /></Link>
         </div>
       </div>


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/291)

I've found and fixed only one link that pointed to the new page and used `<a>` tag.

### Test plan

Maybe... just to see if the `meet our team` link works.