### PR TITLE
Updating RB selfie video link on Join Us page

### DIFF
--- a/website-next/src/shared/containers/join-us/index.js
+++ b/website-next/src/shared/containers/join-us/index.js
@@ -112,7 +112,7 @@ export default class JoinUs extends Component {
                 <ComponentRenderer data={join} />
               </Cell>
               <Cell size={6}>
-                <Video id="110925126" type="vimeo" />
+                <Video id="9Ph7XJfWPys" type="youtube" />
               </Cell>
             </Grid>
             <HR color="red" />


### PR DESCRIPTION
### Motivation

- Original selfie video was hosted on Vimeo and is now gone. This PR updates embed link to the correct video now hosted on Youtube

### Test plan

- Go to Join Us page `/about-us/join-us`. Check that RB selfie video is there and you can play it. 

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
