### PR TITLE
Removed the Publish Lambda from the Commit Site Preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ dev-static: dist/static-site dist/dev-static/index.js dist/sw.js ## Compile the 
 	node dist/dev-static/index.js
 	./node_modules/.bin/http-server ./dist/static-site -p 8000
 
+dev-commit: dist/static-site dist/dev-static/index.js
+
 
 test: ## Run the tests
 	$(MOCHA)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ dev-static: dist/static-site dist/dev-static/index.js dist/sw.js ## Compile the 
 	./node_modules/.bin/http-server ./dist/static-site -p 8000
 
 dev-commit: dist/static-site dist/dev-static/index.js
+	node dist/dev-static/index.js
 
 
 test: ## Run the tests

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ dev-static: dist/static-site dist/dev-static/index.js dist/sw.js ## Compile the 
 	node dist/dev-static/index.js
 	./node_modules/.bin/http-server ./dist/static-site -p 8000
 
+
 dev-commit: dist/static-site dist/dev-static/index.js
 	node dist/dev-static/index.js
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dev-static: dist/static-site dist/dev-static/index.js dist/sw.js ## Compile the 
 	./node_modules/.bin/http-server ./dist/static-site -p 8000
 
 
-dev-commit: dist/static-site dist/dev-static/index.js
+dev-commit: dist/static-site dist/dev-static/index.js dist/sw.js ## Compile the site to HTML locally
 	node dist/dev-static/index.js
 
 

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -18,7 +18,7 @@ createCommitSite() {
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/$COMMIT_REF/sw.js
   make fetch
   make dev-commit
-  aws s3 cp ./dist/static-site s3://$BUCKET_NAME/$COMMIT_REF/
+  aws s3 sync ./dist/static-site s3://$BUCKET_NAME/$COMMIT_REF/
   echo Done!
 
   echo Registering deployment with GitHub

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -16,8 +16,9 @@ createCommitSite() {
   aws s3 sync ./dist/assets-honestly s3://$BUCKET_NAME/$COMMIT_REF/assets-honestly
   aws s3 cp ./dist/robots.txt s3://$BUCKET_NAME/$COMMIT_REF/robots.txt
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/$COMMIT_REF/sw.js
-  make services-deploy
-  make publish-service-invoke
+  make fetch
+  make dev-static
+  aws s3 cp ./dist/static-site s3://$BUCKET_NAME/$COMMIT_REF/
   echo Done!
 
   echo Registering deployment with GitHub

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -12,12 +12,12 @@ createCommitSite() {
   echo Deploying commit preview site to $URL_BASENAME
   make clean
   make build
+  make fetch
+  make dev-commit
   echo Copying assets to S3
   aws s3 sync ./dist/assets-honestly s3://$BUCKET_NAME/$COMMIT_REF/assets-honestly
   aws s3 cp ./dist/robots.txt s3://$BUCKET_NAME/$COMMIT_REF/robots.txt
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/$COMMIT_REF/sw.js
-  make fetch
-  make dev-commit
   aws s3 sync ./dist/static-site/$COMMIT_REF/ s3://$BUCKET_NAME/$COMMIT_REF/
   echo Done!
 

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -18,7 +18,7 @@ createCommitSite() {
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/$COMMIT_REF/sw.js
   make fetch
   make dev-commit
-  aws s3 sync ./dist/static-site s3://$BUCKET_NAME/$COMMIT_REF/
+  aws s3 sync ./dist/static-site/$COMMIT_REF/ s3://$BUCKET_NAME/$COMMIT_REF/
   echo Done!
 
   echo Registering deployment with GitHub

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -17,7 +17,7 @@ createCommitSite() {
   aws s3 cp ./dist/robots.txt s3://$BUCKET_NAME/$COMMIT_REF/robots.txt
   aws s3 cp ./dist/sw.js s3://$BUCKET_NAME/$COMMIT_REF/sw.js
   make fetch
-  make dev-static
+  make dev-commit
   aws s3 cp ./dist/static-site s3://$BUCKET_NAME/$COMMIT_REF/
   echo Done!
 

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -11,7 +11,6 @@ createCommitSite() {
 
   echo Deploying commit preview site to $URL_BASENAME
   make clean
-  make build
   make fetch
   make dev-commit
   echo Copying assets to S3


### PR DESCRIPTION
### Motivation

The commit site and staging share a lambda. This is bad because each push triggers a build which overwrites the lambda, potentially stepping on staging’s toes. To make staging as much like live as possible we want to remove the commit sites reliance on the lambda.

### Test plan

Click the ‘View deployment’ link in this PR. The site it links to was built using the new commit site build process. Test the site works with and without JavaScript, checking errors aren’t written to the console.

### Implementation

Instead of compiling the static site in the publish lamda, we’re compiling it inside Circle CI. The new command `make dev-commit` does the compilation. This command is the same as `make dev-static` apart from it doesn’t start the http-server. Then the compiled files are copied over to s3 like the other assets.

_This change has taken over 25% off the build time. It’s gone down from ~5.30min to ~4min._

Now that lambdas aren’t part of the commit site, you can’t use the commit site to test out changes to lambdas. You’ll have to manually create a new infrastructure stack and test your lambda changes there.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
