### PR TITLE
Removed ‘to’ attribute from anchor tags

### DIFF
--- a/site/components/link/index.js
+++ b/site/components/link/index.js
@@ -4,13 +4,12 @@ import { NavigationLink } from 'navigation-react';
 
 type LinkProps = {[id: string]: any}
 export default function Link(props: LinkProps) {
-  const linkProps = Object.assign({}, props, {
-    stateKey: props.to,
-  });
+  const { to, ...rest } = props;
 
   return (
     <NavigationLink
-      {...linkProps}
+      stateKey={to}
+      {...rest}
     >
       {props.children}
     </NavigationLink>


### PR DESCRIPTION
### Motivation

The `to` attribute isn’t valid for anchor tags, so shouldn’t appear in the HTML. Exclude it from the props passed to the `NavigationLink` component

### Test plan

Check Hyperlinks work and, in particular, that the selected main menu Hyperlink is highlighted

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
