### PR TITLE
GA SPA

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -32,6 +32,15 @@ export function makeApp({ element, state }) {
     stateNavigator.stateContext.title = title;
     const component = route.component({ stateNavigator, title }, props);
     ReactDOM.render(component, element, scrollTo(params));
+
+    if (ga) {
+      console.log('GA exists!', route);
+      ga('set', {
+        page: '/' + route.route,
+        title: route.title + ' | Red Badger',
+      });
+      ga('send', 'pageview');
+    }
   });
   return stateNavigator;
 }

--- a/site/client/index.js
+++ b/site/client/index.js
@@ -33,12 +33,14 @@ export function makeApp({ element, state }) {
     const component = route.component({ stateNavigator, title }, props);
     ReactDOM.render(component, element, scrollTo(params));
 
-    if (ga) {
-      ga('set', {
+    // Google Analytics is defined in the main ejs file
+    // We need to update GA on user navigation event
+    if (ga) { // eslint-disable-line
+      ga('set', { // eslint-disable-line
         page: '/' + route.route,
         title: route.title + ' | Red Badger',
       });
-      ga('send', 'pageview');
+      ga('send', 'pageview'); // eslint-disable-line
     }
   });
   return stateNavigator;

--- a/site/client/index.js
+++ b/site/client/index.js
@@ -34,7 +34,6 @@ export function makeApp({ element, state }) {
     ReactDOM.render(component, element, scrollTo(params));
 
     if (ga) {
-      console.log('GA exists!', route);
       ga('set', {
         page: '/' + route.route,
         title: route.title + ' | Red Badger',


### PR DESCRIPTION
### Motivation

- #359 

When navigating client-side, Google Analytics is not updated on that

### Test plan

- This is only possible to test when running the app locally with `INSERT_TRACKING=true` argument, or on live. You can follow Real time analytics to verify hits.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
