### PR TITLE
Improving check for undefined GA variable

### DIFF
--- a/site/client/index.js
+++ b/site/client/index.js
@@ -35,7 +35,7 @@ export function makeApp({ element, state }) {
 
     // Google Analytics is defined in the main ejs file
     // We need to update GA on user navigation event
-    if (ga) { // eslint-disable-line
+    if ('ga' in window) {
       ga('set', { // eslint-disable-line
         page: '/' + route.route,
         title: route.title + ' | Red Badger',


### PR DESCRIPTION
### Motivation

- When running site in dev mode with no Google Analytics defined, you'll get a nasty `ga is undefined` error in the console. This improves check for the `ga` being undefined and doesn't throw an error in the console.

### Test plan

- Run site in dev mode. Check browser dev console. Make sure there is no `ga` variable related errors.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
