### PR TITLE
Secondary image

### DIFF
--- a/site/fetchers/badger-brain.js
+++ b/site/fetchers/badger-brain.js
@@ -113,7 +113,7 @@ export function getData() {
         lastName
         order
         jobTitle
-        imageUrl
+        primaryImageUrl
         secondaryImageUrl
         slug
         about

--- a/site/fetchers/badger-brain.js
+++ b/site/fetchers/badger-brain.js
@@ -114,6 +114,7 @@ export function getData() {
         order
         jobTitle
         imageUrl
+        secondaryImageUrl
         slug
         about
         skills

--- a/site/pages/badger-profile/index.js
+++ b/site/pages/badger-profile/index.js
@@ -27,7 +27,7 @@ const BadgerProfile = ({ badger }: { badger: Badger }) => {
       <div className={styles.profileContainer}>
         <div className={styles.profilePictureContainer}>
           <img
-            src={badger.imageUrl}
+            src={badger.secondaryImageUrl || badger.imageUrl}
             alt={fullName}
             className={styles.badgerImage}
           />

--- a/site/pages/badger-profile/index.js
+++ b/site/pages/badger-profile/index.js
@@ -27,7 +27,7 @@ const BadgerProfile = ({ badger }: { badger: Badger }) => {
       <div className={styles.profileContainer}>
         <div className={styles.profilePictureContainer}>
           <img
-            src={badger.secondaryImageUrl || badger.imageUrl}
+            src={badger.secondaryImageUrl || badger.primaryImageUrl}
             alt={fullName}
             className={styles.badgerImage}
           />

--- a/site/pages/meet-our-team/index.js
+++ b/site/pages/meet-our-team/index.js
@@ -14,6 +14,7 @@ const getTeam = (badgers, category) => {
     lastName: '',
     slug: '',
     imageUrl: '',
+    secondaryImageUrl: '',
     placeholderImage: '',
     description: '',
     jobAdvert: true,

--- a/site/pages/meet-our-team/index.js
+++ b/site/pages/meet-our-team/index.js
@@ -13,7 +13,7 @@ const getTeam = (badgers, category) => {
     firstName: '',
     lastName: '',
     slug: '',
-    imageUrl: '',
+    primaryImageUrl: '',
     secondaryImageUrl: '',
     placeholderImage: '',
     description: '',

--- a/site/pages/meet-our-team/team-slice/badger-profile/index.js
+++ b/site/pages/meet-our-team/team-slice/badger-profile/index.js
@@ -10,6 +10,7 @@ export type Badger = {
   lastName: string,
   slug: string,
   imageUrl: string,
+  secondaryImageUrl: string,
   placeholderImage: string,
   description: string,
   jobAdvert: boolean,

--- a/site/pages/meet-our-team/team-slice/badger-profile/index.js
+++ b/site/pages/meet-our-team/team-slice/badger-profile/index.js
@@ -9,7 +9,7 @@ export type Badger = {
   firstName: string,
   lastName: string,
   slug: string,
-  imageUrl: string,
+  primaryImageUrl: string,
   secondaryImageUrl: string,
   placeholderImage: string,
   description: string,
@@ -24,7 +24,7 @@ const BadgerProfile = ({ badger }: { badger: Badger }) => {
   return (
     <Link to="badger" navigationData={{ slug: badger.slug }} className={styles.badgerProfile}>
       <img
-        src={badger.loaded ? badger.imageUrl : badger.placeholderImage}
+        src={badger.loaded ? badger.primaryImageUrl : badger.placeholderImage}
         alt={fullName}
         className={styles.badgerImage}
         aria-hidden

--- a/site/types/badger.js
+++ b/site/types/badger.js
@@ -7,6 +7,7 @@ type Badger = {
   jobTitle: string,
   slug: string,
   imageUrl: string,
+  secondaryImageUrl: string,
   about: string,
   skills: string,
   achievements: string,

--- a/site/types/badger.js
+++ b/site/types/badger.js
@@ -6,7 +6,7 @@ type Badger = {
   lastName: string,
   jobTitle: string,
   slug: string,
-  imageUrl: string,
+  primaryImageUrl: string,
   secondaryImageUrl: string,
   about: string,
   skills: string,


### PR DESCRIPTION
### Motivation

As a badger I'd like to have 2 image options available for my profile

* added secondaryImageUrl to the badger profile page (primary image is a fallback)
* renamed imageUrl to primaryImageUrl

This PR merge must go along with: https://github.com/redbadger/badger-brain/pull/98

### Test plan

- Add secondary image in prismic and see if it is visible on badger's profile page. When a secondary image is not specified it should fallback to the original image.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
