### PR TITLE
Changing Badger Brain request for badger profile image

### DIFF
--- a/site/fetchers/badger-brain.js
+++ b/site/fetchers/badger-brain.js
@@ -87,7 +87,7 @@ export function getData() {
         lastName
         jobTitle
         startDate
-        imageUrl
+        primaryImageUrl
         categories {
           name
           slug


### PR DESCRIPTION
### Motivation

- Badger Brain on staging has been updated with the Badger profile support for primary and secondary images. This however breaks existing GraphQL query on master which relies on `imageURL` param for badgers, which in turn doesn't exists anymore. 

### Test plan

- Build and deploy the Website Honestly. It should build and fetch data during build without errors.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
