### PR TITLE
Adjusting styles of inline links

### DIFF
--- a/site/css/_links.css
+++ b/site/css/_links.css
@@ -11,11 +11,12 @@
  */
 
 .bodyLink {
-  color: badgerRed;
+  color: badgerBlack;
+  transition: all 0.2s ease;
 }
 
 .bodyLink:hover {
-  color: badgerBlack;
+  color: badgerRed;
 }
 
 .bodyUnderlineLink {

--- a/website-next/src/shared/components/jobs/style.css
+++ b/website-next/src/shared/components/jobs/style.css
@@ -2,7 +2,7 @@
 
 .title {
   composes: heroFont from "../fonts/style.css";
-  display: block;
+  display: inline;
   font-size: 1.55em;
   text-decoration: none;
   color: badgerBlack;
@@ -10,7 +10,7 @@
 }
 
 .title:hover {
-  color: badgerRed;
+  border-bottom: 1px solid badgerRed;
 }
 
 .icon {

--- a/website-next/src/shared/components/typography/style.css
+++ b/website-next/src/shared/components/typography/style.css
@@ -17,12 +17,14 @@
 
 .a,
 .typography a {
-  color: badgerRed;
+  color: badgerBlack;
+  border-bottom: 1px solid badgerRed;
+  transition: all 0.2s ease;
 }
 
 .a:hover,
 .typography a:hover {
-  color: badgerBlack;
+  color: badgerRed;
 }
 
 .p,

--- a/website-next/src/shared/containers/event/index.js
+++ b/website-next/src/shared/containers/event/index.js
@@ -53,7 +53,7 @@ export default class Event extends Component {
                         <HR color="grey" />
                         <div className={styles.moreEvents}>
                           <Link to="events">
-                            <span>&lt; More events</span>
+                            <span>More events</span>
                           </Link>
                         </div>
                     </div>

--- a/website-next/src/shared/containers/event/style.css
+++ b/website-next/src/shared/containers/event/style.css
@@ -129,6 +129,8 @@
   color: black;
   text-decoration: none;
   font-weight: bold;
+  transition: all 0.2s ease;
+  border-bottom: 1px solid red;
 }
 
 .moreEvents a:hover, .moreEvents a:focus {

--- a/website-next/src/shared/containers/job/style.css
+++ b/website-next/src/shared/containers/job/style.css
@@ -1,5 +1,5 @@
 @value tablet from "../../components/variables/breakpoints.css";
-@value badgerWhite, badgerBlack from "../../../../../site/css/_colors.css";
+@value badgerWhite, badgerBlack, badgerRed from "../../../../../site/css/_colors.css";
 
 .background {
   background-color: badgerWhite;
@@ -27,7 +27,8 @@
 
 .linkBack {
   composes: bodyLink from "../../../../../site/css/_links.css";
-  display: block;
+  border-bottom: 1px solid badgerRed;
+  display: inline-block;
   margin-bottom: 25px;
   composes: sansSerif from "../../../../../site/css/typography/_fonts.css";
 


### PR DESCRIPTION
![giphy 17](https://cloud.githubusercontent.com/assets/487468/22892937/231d7e46-f20c-11e6-955d-39eaffb04866.gif)

### Motivation

- Adjusting styles of inline links according to the RB branding styleguide http://brand.red-badger.com/d/WEl30uS4YzKw/red-badger-styleguide-style-guide#/elements/links

### Test plan

I've identified following places where you can see links in the body of text on Website:
* Job page - description
* Event page - description

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
