### PR TITLE
He disabled background scrolling with this one simple trick. Senior developers hate him. 😱

### DIFF
--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -14,37 +14,23 @@ export default class SmallScreenNav extends React.Component {
   }
 
   handleInputChange = event => {
-    this.scrollLock();
+    if (event.target.checked) {
+      document.body.style.position = 'fixed';
+      this.smallScreenNav.scrollTop = 0;
+    } else {
+      document.body.style.position = 'relative';
+    }
     this.setState({
       navOpen: event.target.checked,
     });
   }
 
   closeMenu = () => {
-    this.scrollRelease();
+    document.body.style.position = 'relative';
     this.setState({
       navOpen: false,
     });
     return true;
-  }
-
-  scrollLock = () => {
-    this.smallScreenNav.addEventListener('wheel', this.onScrollHandler, false);
-    this.smallScreenNav.addEventListener('touchmove', this.onScrollHandler, false);
-  }
-
-  scrollRelease = () => {
-    this.smallScreenNav.removeEventListener('wheel', this.onScrollHandler, false);
-    this.smallScreenNav.removeEventListener('touchmove', this.onScrollHandler, false);
-  }
-
-  onScrollHandler = e => {
-    e.stopImmediatePropagation();
-    e.preventDefault();
-  }
-
-  componentWillUnmount = () => {
-    this.scrollRelease();
   }
 
   render() {
@@ -52,7 +38,7 @@ export default class SmallScreenNav extends React.Component {
     const navTabIndex = navOpen ? 0 : -1;
 
     return (
-      <div ref={c => { this.smallScreenNav = c; }} className={styles.smallScreenNavComponent}>
+      <div className={styles.smallScreenNavComponent}>
         <div className={styles.triggerContainer}>
           <label
             htmlFor="burger"
@@ -77,6 +63,7 @@ export default class SmallScreenNav extends React.Component {
             onClick={this.closeMenu}
           />
           <div
+            ref={c => { this.smallScreenNav = c; }}
             className={styles.smallScreenNavWrapper}
           >
             <label htmlFor="burger" className={styles.menuCloseButton}>Close</label>

--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -75,6 +75,7 @@
   right: 0;
   left: 54px;
   display: none;
+  overflow-y: scroll;
 }
 
 .overlay .mediumScreenNav {


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/325)

😎 Prevents background content to scroll when menu is open. 
😎 The menu itself stays scrollable.

### Test plan

- This only applies to mobile devices while touching the screen.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [x] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [ ] Tester approved
