### PR TITLE
prevent screen reader to access body content when mobile menu is open

### DIFF
--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -13,12 +13,22 @@ export default class SmallScreenNav extends React.Component {
     };
   }
 
+  documentBodyLock = () => {
+    document.getElementById('lockableElement').setAttribute('aria-hidden', true);
+    document.body.style.position = 'fixed';
+    this.smallScreenNav.scrollTop = 0;
+  }
+
+  documentBodyRelease = () => {
+    document.getElementById('lockableElement').removeAttribute('aria-hidden');
+    document.body.style.position = 'relative';
+  }
+
   handleInputChange = event => {
     if (event.target.checked) {
-      document.body.style.position = 'fixed';
-      this.smallScreenNav.scrollTop = 0;
+      this.documentBodyLock();
     } else {
-      document.body.style.position = 'relative';
+      this.documentBodyRelease();
     }
     this.setState({
       navOpen: event.target.checked,
@@ -26,7 +36,7 @@ export default class SmallScreenNav extends React.Component {
   }
 
   closeMenu = () => {
-    document.body.style.position = 'relative';
+    this.documentBodyRelease();
     this.setState({
       navOpen: false,
     });

--- a/site/components/header/small-screen-nav.js
+++ b/site/components/header/small-screen-nav.js
@@ -14,13 +14,13 @@ export default class SmallScreenNav extends React.Component {
   }
 
   documentBodyLock = () => {
-    document.getElementById('lockableElement').setAttribute('aria-hidden', true);
+    document.getElementById('mainContent').setAttribute('aria-hidden', true);
     document.body.style.position = 'fixed';
     this.smallScreenNav.scrollTop = 0;
   }
 
   documentBodyRelease = () => {
-    document.getElementById('lockableElement').removeAttribute('aria-hidden');
+    document.getElementById('mainContent').removeAttribute('aria-hidden');
     document.body.style.position = 'relative';
   }
 

--- a/site/layout/index.js
+++ b/site/layout/index.js
@@ -21,7 +21,7 @@ export default class Layout extends React.Component {
     return (
       <div className={styles.application}>
         <Header />
-        <div className={styles.background}>{this.props.children}</div>
+        <div id="lockableElement" className={styles.background}>{this.props.children}</div>
         <Footer />
       </div>
     );

--- a/site/layout/index.js
+++ b/site/layout/index.js
@@ -21,7 +21,7 @@ export default class Layout extends React.Component {
     return (
       <div className={styles.application}>
         <Header />
-        <div id="lockableElement" className={styles.background}>{this.props.children}</div>
+        <div id="mainContent" className={styles.background}>{this.props.children}</div>
         <Footer />
       </div>
     );


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/325)

![wptdgln](https://cloud.githubusercontent.com/assets/8601093/23133358/b536da26-f788-11e6-9c99-ea7dd1cdf002.gif)

### Test plan

* Grab an iPhone
* Turn on Voiceover (Settings -> General -> Accessibility)
* Go to the PR deployment build
* Open mobile menu
* Click in visible bit of text in background

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
