### PR TITLE
Moved meta tags before noscript so that they're not moved to body

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -26,6 +26,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/7069172/css/fonts.css" />
     <title><% if (typeof title !== 'undefined') {%><%= title %><% } %></title>
+    <% if (typeof meta !== 'undefined') { %><%= meta %><% } %>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>
     <% if (typeof tracking !== 'undefined' && tracking) { %>
     <script async type="text/javascript" src="https://secure.leadforensics.com/js/77932.js"></script><noscript><img src="https://secure.leadforensics.com/77932.png" style="display: none;" /></noscript>
@@ -38,7 +39,6 @@
         ga('create', 'UA-16654919-1', 'auto');
         ga('send', 'pageview');
     </script><% } %>
-    <% if (typeof meta !== 'undefined') { %><%= meta %><% } %>
   </head>
   <body>
     <div class="js-app">


### PR DESCRIPTION
### Motivation

When JavaScript is off the lead forensics png is included in the head. Img elements aren't allowed in the head so it's moved into the body along with the meta tags that come after it. We fixed it by moving the meta tags before the lead forensics. (The lead forensics noscript should probably be moved into the body at a later date)

TODO: write a motivation.

### Test plan

Test Open Graph and Twitter work and that the meta tags appear in the head section when JavaScript is off

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
