### PR TITLE
Fixing header typo for 'About us'

### DIFF
--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -23,7 +23,7 @@ const Header = () => {
           </li>
           <li>
             <Link to="aboutUsPage" activeCssClass={styles.activeNavLink}>
-              About Us
+              About us
             </Link>
           </li>
           <li><a href="/blog/">Blog</a></li>

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -36,7 +36,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     route: 'our-work',
   },
   {
-    title: 'About Us',
+    title: 'About us',
     key: 'aboutUsPage',
     route: 'about-us',
     stateToProps: ({ contactUsURL, tweets, instagramPosts }) => ({


### PR DESCRIPTION
### Motivation

- Fixing issue #423 

### Test plan

- Check the nav has 'About us' wherever it's used.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

![spring vibes](https://media.giphy.com/media/xUPGcxJifn7dEpmqcg/200w_d.gif)