### PR TITLE
'Sign up to webinar' slice created, added to technology page to repla…

### DIFF
--- a/site/pages/technology/index.js
+++ b/site/pages/technology/index.js
@@ -6,7 +6,7 @@ import InlineSVG from 'svg-inline-react';
 import styles from './style.css';
 
 import BlogSlice from './blog-slice';
-import NewsletterSlice from './newsletter-slice';
+import WebinarSignupSlice from './webinar-signup-slice';
 
 import techRoundTableImage from './images/techroundtable.png';
 import slackSVG from './images/slack.svg';
@@ -68,7 +68,7 @@ export default ({ triedAndTestedBlogPosts, growingTrendsBlogPosts }: TechPagePro
         </section>
       </section>
     </div>
-    <NewsletterSlice />
+    <WebinarSignupSlice />
     <section className={styles.pastAndFuture}>
       <div className={styles.leftBlogs}>
         <BlogSlice blogPosts={triedAndTestedBlogPosts} title={'Tried and tested'} />

--- a/site/pages/technology/webinar-signup-slice/index.js
+++ b/site/pages/technology/webinar-signup-slice/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from '../style.css';
+
+const webinarLink =
+  'https://attendee.gotowebinar.com/register/4215309162791382274?source=RB-Tech-website';
+
+export default () =>
+  <section className={styles.webinar}>
+    <div className={styles.webinarInner}>
+      <h2 className={styles.webinarText}>{"We're hosting a webinar!"}</h2>
+      <a
+        className={styles.webinarButton}
+        href={webinarLink}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Sign up to attend
+      </a>
+    </div>
+  </section>;

--- a/site/pages/technology/webinar-signup-slice/index.js
+++ b/site/pages/technology/webinar-signup-slice/index.js
@@ -1,5 +1,14 @@
 import React from 'react';
+import ReactGA from 'react-ga';
 import styles from '../style.css';
+
+
+const trackAnalytics = title => () =>
+   ReactGA.event({
+     category: 'TechnologyPage',
+     action: title,
+     label: `From: ${window.location.pathname}`,
+   });
 
 const webinarLink =
   'https://attendee.gotowebinar.com/register/4215309162791382274?source=RB-Tech-website';
@@ -13,6 +22,7 @@ export default () =>
         href={webinarLink}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={trackAnalytics('Webinar-technology page -button')}
       >
         Sign up to attend
       </a>


### PR DESCRIPTION
### Motivation

Created a new slice for signing up to the webinar on the tech page, replacing 'sign up to newsletter slice'.  Newletter slice component is left unchnaged within 'Technology' page directory, in case it is needed for future use.

### Test plan

- TODO: Write a test plan.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
