### PR TITLE
Avoid profile component reuse

### DIFF
--- a/site/pages/meet-our-team/team-slice/index.js
+++ b/site/pages/meet-our-team/team-slice/index.js
@@ -85,9 +85,9 @@ class TeamSlice extends React.Component {
     return (
       <div>
         <ul className={styles.badgers}>
-          {paginate(badgers, page, loadAll).map((badger, i) =>
+          {paginate(badgers, page, loadAll).map(badger =>
             <li
-              key={i}
+              key={badger.slug}
               className={styles.badger}
               ref={el => {
                 this.badgerElements[badger.slug] = el;


### PR DESCRIPTION
React reuses the component whenever it can which leads to the user seeing the previous state until the image loads.

### Motivation

See #408 for details.

### Test plan

Check image loading on slow connection while switching between filters on the team page.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
