### PR TITLE
Add fetching blog posts by multiple tags for the tech page

### DIFF
--- a/state/index.js
+++ b/state/index.js
@@ -16,15 +16,15 @@ const toDict = (array, keyFn) =>
       ...obj,
       [keyFn(item)]: item,
     }),
-    {},
+    {}
   );
 
 const getSiteState = () =>
   Promise.props({
     jobs: getJobs(fetch, process.env.WORKABLE_API_KEY),
-    featuredBlogPosts: getBlogPosts('featured'),
-    triedAndTestedBlogPosts: getBlogPosts('tried-and-tested', 5),
-    growingTrendsBlogPosts: getBlogPosts('growing-trends', 5),
+    featuredBlogPosts: getBlogPosts(['featured']),
+    triedAndTestedBlogPosts: getBlogPosts(['tried-and-tested', 'tried and tested'], 5),
+    growingTrendsBlogPosts: getBlogPosts(['growing-trends', 'growing trends'], 5),
     tweets: getTweets(fetch, process.env.TWITTER_KEY, process.env.TWITTER_SECRET),
     instagramPosts: getPosts(fetch),
     data: getData(),


### PR DESCRIPTION
### Motivation

Currently the tags for the tech page are `tried-and-tested` and `growing-trends` which show up as 'Tried-And-Tested' and 'Growing-Trends' in the Squarespace template. We would like to remove the hyphens however the Squarespace templating language doesn't provide a formatter for this.

Instead this PR allows fetching both with and without hyphens so we can change the tags over in Squarespace.

### Test plan

- TODO: Write a test plan.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
