### PR TITLE
Fix js bundle path in dev build

### DIFF
--- a/webpack.dev.browser.config.js
+++ b/webpack.dev.browser.config.js
@@ -9,6 +9,9 @@ const devAppConfig = webpackMerge(baseConfig, {
   entry: {
     'dev-app': ['babel-polyfill', './dev/browser-app/index.js'],
   },
+  output: {
+    publicPath: '/',
+  },
   target: 'web',
   devServer: {
     inline: true,


### PR DESCRIPTION
### Motivation

- When running the `make dev` build I found that the js bundle wasn't loading on nested paths such as the case studies.

### Test plan

- TODO: Write a test plan.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
