### PR TITLE
Fm amends

### DIFF
--- a/site/components/contact-box/style.css
+++ b/site/components/contact-box/style.css
@@ -17,6 +17,7 @@
 .contactBox__button {
   composes: smallButton from "../../css/_links.css";
   cursor: pointer;
+  border-radius: 0;
 }
 
 

--- a/site/pages/our-work/case-study/fortnum-and-mason/index.js
+++ b/site/pages/our-work/case-study/fortnum-and-mason/index.js
@@ -147,7 +147,7 @@ const CaseStudyFortnumAndMason = ({ contactUsURL }: CaseStudyFortnumAndMasonProp
           <span className={styles.content__redTitle}>{'Creating lasting change.'}</span>
           Increasing conversion, sales and mobile visits and winning multiple awards
         </h2>
-        <div className={cx(styles.content__float, styles['content__float--left'])}>
+        <div className={cx(styles.content__float, styles['content__float--left'], styles['content__float--content-hack'])}>
           <img
             src={tabletCheckoutImage}
             className={styles.tabletImage}

--- a/site/pages/our-work/case-study/fortnum-and-mason/index.js
+++ b/site/pages/our-work/case-study/fortnum-and-mason/index.js
@@ -147,7 +147,13 @@ const CaseStudyFortnumAndMason = ({ contactUsURL }: CaseStudyFortnumAndMasonProp
           <span className={styles.content__redTitle}>{'Creating lasting change.'}</span>
           Increasing conversion, sales and mobile visits and winning multiple awards
         </h2>
-        <div className={cx(styles.content__float, styles['content__float--left'], styles['content__float--content-hack'])}>
+        <div
+          className={cx(
+            styles.content__float,
+            styles['content__float--left'],
+            styles['content__float--content-hack'],
+          )}
+        >
           <img
             src={tabletCheckoutImage}
             className={styles.tabletImage}

--- a/site/pages/our-work/case-study/fortnum-and-mason/style.css
+++ b/site/pages/our-work/case-study/fortnum-and-mason/style.css
@@ -123,6 +123,10 @@
     float: left;
     margin: 5px 40px 30px 12%;
   }
+  
+  .content__float--content-hack {
+    margin-bottom: 35px;
+  }
 
   .listBoxContainer {
     margin-left: 64px;

--- a/site/pages/our-work/case-study/fortnum-and-mason/style.css
+++ b/site/pages/our-work/case-study/fortnum-and-mason/style.css
@@ -18,9 +18,8 @@
 
 .header__image {
   max-width: 100%;
-  position: relative;
-  left: 50%;
-  transform: translateX(-50%);
+  max-height: 456px;
+  margin: 0 auto;
 }
 
 .content {


### PR DESCRIPTION
### Motivation

- @clmntnbrn asked the following fixes:
 - [ ] Restrict header height
 - [ ] Remove border radius on _product in mind?_ button
 - [ ] Set float content in one column when just one line is below the image
### Test plan
Go to [F & M case study page](https://www-staging.red-badger.com/0362a8f/our-work/case-study/fortnum-and-mason/)

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [x] Tester approved
