### PR TITLE
Typography amend

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -25,8 +25,6 @@
     <link rel="icon" href="/assets-honestly/favicons/favicon-194x194.png" type="image/png" sizes="194x194">
     <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/6842972/css/fonts.css" />
-    <!-- <link rel="preload" href="https://cloud.typography.com/7838134/6842972/css/fonts.css" as="style" onload="this.rel='stylesheet'" />
-    <noscript><link rel="stylesheet" href="https://cloud.typography.com/7838134/6842972/css/fonts.css"></noscript> -->
     <title><% if (typeof title !== 'undefined') {%><%= title %><% } %></title>
     <% if (typeof meta !== 'undefined') { %><%= meta %><% } %>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -24,8 +24,9 @@
     <link rel="icon" href="/assets-honestly/favicons/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="icon" href="/assets-honestly/favicons/favicon-194x194.png" type="image/png" sizes="194x194">
     <link rel="manifest" href="/manifest.json">
-    <link rel="preload" href="https://cloud.typography.com/7838134/6842972/css/fonts.css" as="style" onload="this.rel='stylesheet'" />
-    <noscript><link rel="stylesheet" href="https://cloud.typography.com/7838134/6842972/css/fonts.css"></noscript>
+    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7838134/6842972/css/fonts.css" />
+    <!-- <link rel="preload" href="https://cloud.typography.com/7838134/6842972/css/fonts.css" as="style" onload="this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="https://cloud.typography.com/7838134/6842972/css/fonts.css"></noscript> -->
     <title><% if (typeof title !== 'undefined') {%><%= title %><% } %></title>
     <% if (typeof meta !== 'undefined') { %><%= meta %><% } %>
     <% if (typeof cssPath !== 'undefined') { %><link rel="stylesheet" href="<%= cssPath %>" type="text/css" charset="utf-8"><% } %>


### PR DESCRIPTION
### Motivation

- We were doing 2 different calls to typography cloud causing a redirect loop and making fonts rendering twice 

### Test plan

- Go to any page on the site [https://www-staging.red-badger.com/272ae4e/](https://www-staging.red-badger.com/272ae4e/) and on document ready should render fonts without "flickering"

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
