### PR TITLE
Css reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "navigation-react": "^2.0.5",
     "node-fetch": "^1.6.3",
     "node-hook": "^0.4.0",
+    "normalize.css": "^7.0.0",
     "param-case": "^2.1.0",
     "pathseg": "^1.0.2",
     "picturefill": "^3.0.2",

--- a/site/layout/style.css
+++ b/site/layout/style.css
@@ -1,3 +1,4 @@
+@import "normalize.css/normalize.css";
 @import "reset-css/reset.css";
 
 * {
@@ -7,4 +8,8 @@
 html, body {
   overflow-x: hidden;
   position: relative;
+}
+
+button {
+  border-radius: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,6 +5089,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize.css@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
### Motivation

Chrome has introduced border radius on all buttons in v62 user agent stylesheet. Thank you Chrome 😞 

So we add another CSS reset ( normalize.css ) and set a CSS button greedy selector to override that

TODO: write a motivation.

Please go to [https://www-staging.red-badger.com/b70b238/](https://www-staging.red-badger.com/b70b238/) and check all buttons on all pages

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [x] Tester approved
