### PR TITLE
Change YouTube URL on join us page

### DIFF
--- a/site/pages/join-us/index.js
+++ b/site/pages/join-us/index.js
@@ -118,7 +118,7 @@ export default function JoinUs({ jobs }) {
               <ComponentRenderer data={join} />
             </Cell>
             <Cell size={6}>
-              <Video title="Red Badger selfie video" id="p-hchy70q-U" type="youtube" />
+              <Video title="Red Badger selfie video" id="dqJuBdCf-rA" type="youtube" />
             </Cell>
           </Grid>
           <HR color="red" />


### PR DESCRIPTION
### Motivation

We update Join Us YouTube video to be this [one](https://www.youtube.com/watch?v=dqJuBdCf-rA), so we update the URL on `/about-us/join-us`
### Test plan

Please, go to [https://www-staging.red-badger.com/47e07c8/about-us/join-us/](https://www-staging.red-badger.com/47e07c8/about-us/join-us/) and you will see this [video](https://www.youtube.com/watch?v=dqJuBdCf-rA)
### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [x] Tester approved
