### PR TITLE
Add link to fortnum and mason case study

### DIFF
--- a/site/components/link/index.js
+++ b/site/components/link/index.js
@@ -3,6 +3,13 @@ import React, { PropTypes } from 'react';
 import { StateNavigator } from 'navigation';
 import { NavigationLink } from 'navigation-react';
 
+export type LinkProps = {
+  to: string,
+  children?: Node,
+  activeCssClass?: string,
+  target?: string,
+};
+
 export default class Link extends React.Component {
   static contextTypes = {
     // The stateNavigator is provided by navigation-react and provides
@@ -10,15 +17,18 @@ export default class Link extends React.Component {
     stateNavigator: PropTypes.instanceOf(StateNavigator),
   };
 
-  static propTypes = {
-    to: PropTypes.string.isRequired,
-    children: PropTypes.node.isRequired,
-    activeCssClass: PropTypes.string,
-  };
+  constructor(props: LinkProps) {
+    super(props);
+
+    this.shouldNavigate = this.shouldNavigate.bind(this);
+  }
 
   getStateNavigator(): StateNavigator {
     return this.context.stateNavigator;
   }
+
+  shouldNavigate: () => boolean;
+  props: LinkProps;
 
   /**
    * Checks if the currently active state is a child (direct or nested) of
@@ -39,12 +49,21 @@ export default class Link extends React.Component {
     return false;
   }
 
+  shouldNavigate(): boolean {
+    return this.props.target !== '_blank';
+  }
+
   render() {
     const { to, ...rest } = this.props;
     const appliedCssClass = this.hasActiveChild() ? this.props.activeCssClass : '';
 
     return (
-      <NavigationLink stateKey={to} className={appliedCssClass} {...rest}>
+      <NavigationLink
+        stateKey={to}
+        className={appliedCssClass}
+        navigating={this.shouldNavigate}
+        {...rest}
+      >
         {this.props.children}
       </NavigationLink>
     );

--- a/site/components/link/test.js
+++ b/site/components/link/test.js
@@ -66,4 +66,27 @@ describe('components/link', () => {
     );
     expect(wrapper.hasClass('active')).to.equal(false);
   });
+
+  describe('#shouldNavigate', () => {
+    it('returns true when target is not set', () => {
+      const wrapper = shallow(<Link to="foo">Hello</Link>, {
+        context: createMockContext('bar'),
+      });
+
+      expect(wrapper.instance().shouldNavigate()).to.equal(true);
+    });
+
+    it('returns false when target is set to _blank', () => {
+      const wrapper = shallow(
+        <Link to="foo" target="_blank">
+          Hello
+        </Link>,
+        {
+          context: createMockContext('bar'),
+        },
+      );
+
+      expect(wrapper.instance().shouldNavigate()).to.equal(false);
+    });
+  });
 });

--- a/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/index.js
+++ b/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/index.js
@@ -5,6 +5,7 @@ import WhatToReadNext from '../what-to-read-next';
 import ContactUs from '../../../../slices/contact-us-slice';
 import Social from '../../../../components/social';
 import Picture from '../../../../components/picture';
+import Link from '../../../../components/link';
 
 import headerL from './images/header-l.jpg';
 import headerM from './images/header-m.jpg';
@@ -48,7 +49,10 @@ const FMTeaCaseStudy = ({ contactUsURL }: CaseStudyFMTeaProps) => (
           Since 2014, we’ve been working with Fortnum & Mason to drive business growth through
           digital transformation via an ongoing programme of tech initiatives across the website
           that helps make everyday special for their customers across all touch points. You can read
-          about our award-winning work on the website here.
+          about our award-winning work on the website{' '}
+          <Link to="fortnumAndMasonCaseStudy" className={styles.link}>
+            here
+          </Link>.
         </p>
         <p className={styles.content__paragraph}>
           Since then, the focus has been on increasing the awareness and accessibility of a wide

--- a/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/index.js
+++ b/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/index.js
@@ -50,7 +50,7 @@ const FMTeaCaseStudy = ({ contactUsURL }: CaseStudyFMTeaProps) => (
           digital transformation via an ongoing programme of tech initiatives across the website
           that helps make everyday special for their customers across all touch points. You can read
           about our award-winning work on the website{' '}
-          <Link to="fortnumAndMasonCaseStudy" className={styles.link}>
+          <Link to="fortnumAndMasonCaseStudy" className={styles.link} target="_blank">
             here
           </Link>.
         </p>

--- a/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/style.css
+++ b/site/pages/our-work/case-study/fortnum-and-mason-digital-transformation/style.css
@@ -92,6 +92,10 @@
   display: none;
 }
 
+.link {
+  composes: bodyUnderlineLink from "../../../../css/_links.css";
+}
+
 @media mediumScreen {
 
   .content__paragraph {


### PR DESCRIPTION
### Motivation

We add a link to the [Fortnum and Mason case study](https://www-staging.red-badger.com/our-work/case-study/fortnum-and-mason/) from the [Fortnum and Mason digital transformation page](https://red-badger.com/our-work/case-study/fortnum-and-mason-digital-transformation/).

We used [the recommended styling from the Style guide](http://brand.red-badger.com/d/WEl30uS4YzKw/red-badger-style-guide#/elements/links).

### Screenshot

![screen shot 2017-12-13 at 16 32 46](https://user-images.githubusercontent.com/5112255/33950122-71e01f74-e023-11e7-9684-e646191703df.png)




### Test plan

- Visit https://www-staging.red-badger.com/876e3bc/our-work/case-study/fortnum-and-mason-digital-transformation/
- Check the styling of the link
- Check that the link goes to the correct page

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
