### PR TITLE
Fix highlight of nav items when a child of a child is active

### DIFF
--- a/site/components/header/index.js
+++ b/site/components/header/index.js
@@ -28,11 +28,7 @@ const Header = () => {
       <nav className={styles.mediumScreenNavContainer} role="navigation">
         <ul role="listbox" className={styles.mediumScreenNav}>
           <li className={styles.navItemWithChild}>
-            <Link
-              to="whatWeDoPage"
-              activeCssClass={styles.activeNavLink}
-              childActiveCssClass={styles.activeNavLink}
-            >
+            <Link to="whatWeDoPage" activeCssClass={styles.activeNavLink}>
               <span onClick={trackAnalytics('What we do')}>What we do</span>
             </Link>
             <ul className={styles.mediumScreenChildList}>
@@ -49,11 +45,7 @@ const Header = () => {
             </ul>
           </li>
           <li className={styles.navItemWithChild}>
-            <Link
-              to="aboutUsPage"
-              activeCssClass={styles.activeNavLink}
-              childActiveCssClass={styles.activeNavLink}
-            >
+            <Link to="aboutUsPage" activeCssClass={styles.activeNavLink}>
               <span onClick={trackAnalytics('About us')}>About us</span>
             </Link>
             <ul className={styles.mediumScreenChildList}>

--- a/site/components/link/index.js
+++ b/site/components/link/index.js
@@ -20,6 +20,11 @@ export default class Link extends React.Component {
     return this.context.stateNavigator;
   }
 
+  /**
+   * Checks if the currently active state is a child (direct or nested) of
+   * the state specified in the `to` property. Returns true, if this is the
+   * case; otherwise false.
+   */
   hasActiveChild(): boolean {
     const stateNavigator = this.getStateNavigator();
     let state = stateNavigator.stateContext.state;

--- a/site/components/link/index.js
+++ b/site/components/link/index.js
@@ -13,7 +13,7 @@ export default class Link extends React.Component {
   static propTypes = {
     to: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
-    childActiveCssClass: PropTypes.string,
+    activeCssClass: PropTypes.string,
   };
 
   getStateNavigator(): StateNavigator {
@@ -21,13 +21,22 @@ export default class Link extends React.Component {
   }
 
   hasActiveChild(): boolean {
-    const currentStateParent = this.getStateNavigator().stateContext.state.parentKey;
-    return currentStateParent === this.props.to;
+    const stateNavigator = this.getStateNavigator();
+    let state = stateNavigator.stateContext.state;
+    while (state.parentKey) {
+      if (state.parentKey === this.props.to) {
+        return true;
+      }
+
+      state = stateNavigator.states[state.parentKey];
+    }
+
+    return false;
   }
 
   render() {
-    const { to, childActiveCssClass, ...rest } = this.props;
-    const appliedCssClass = this.hasActiveChild() ? childActiveCssClass : '';
+    const { to, ...rest } = this.props;
+    const appliedCssClass = this.hasActiveChild() ? this.props.activeCssClass : '';
 
     return (
       <NavigationLink stateKey={to} className={appliedCssClass} {...rest}>

--- a/site/components/link/test.js
+++ b/site/components/link/test.js
@@ -12,6 +12,13 @@ function createMockContext(parentKey) {
           parentKey,
         },
       },
+      states: {
+        foo: {},
+        bar: {},
+        barChild: {
+          parentKey: 'bar',
+        },
+      },
     },
   };
 }
@@ -24,9 +31,9 @@ describe('components/link', () => {
     expect(wrapper.text()).to.equal('<NavigationLink />');
   });
 
-  it('applies childActiveCssClass when the specified `to` state is a parent of the current state', () => {
+  it('applies activeCssClass when the specified `to` state is a direct parent of the current state', () => {
     const wrapper = shallow(
-      <Link to="foo" childActiveCssClass="active">
+      <Link to="foo" activeCssClass="active">
         Hello
       </Link>,
       {
@@ -36,9 +43,21 @@ describe('components/link', () => {
     expect(wrapper.hasClass('active')).to.equal(true);
   });
 
-  it('does not apply childActiveCssClass when the specified `to` state is not a parent of the current state', () => {
+  it('applies activeCssClass when the specified `to` state is a parent of the current state', () => {
     const wrapper = shallow(
-      <Link to="foo" childActiveCssClass="active">
+      <Link to="bar" activeCssClass="active">
+        Hello
+      </Link>,
+      {
+        context: createMockContext('barChild'),
+      },
+    );
+    expect(wrapper.hasClass('active')).to.equal(true);
+  });
+
+  it('does not apply activeCssClass when the specified `to` state is not a parent of the current state', () => {
+    const wrapper = shallow(
+      <Link to="foo" activeCssClass="active">
         Hello
       </Link>,
       {

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -56,6 +56,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     route: 'jobs/{slug}',
     stateToProps: (state, params = {}) => ({ job: state.job[params.slug] }),
     gen: state => state.jobs.map(({ slug }) => ({ slug })),
+    parentKey: 'joinUs',
   },
   {
     title: 'Events',
@@ -75,6 +76,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
         year,
         slug,
       })),
+    parentKey: 'events',
   },
   {
     title: getBadgersTitle,
@@ -93,6 +95,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
       badger: state.badger[params.slug],
     }),
     gen: state => state.badgers.map(({ slug }) => ({ slug })),
+    parentKey: 'badgers',
   },
   {
     title: 'Retailer case study',
@@ -101,6 +104,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Fortnum & Mason case study',
@@ -109,6 +113,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Fortnum & Mason digital transformation',
@@ -117,6 +122,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Financial Times case study',
@@ -125,6 +131,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'BMW Virtual Museum case study',
@@ -133,6 +140,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'BBC Now case study',
@@ -141,6 +149,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Haller Foundation case study',
@@ -149,6 +158,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Sky CMS case study',
@@ -157,6 +167,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Sky case study',
@@ -165,6 +176,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
   {
     title: 'Technology',
@@ -203,5 +215,6 @@ export const routeDefinitions: Array<RouteDefinition> = [
     stateToProps: ({ contactUsURL }) => ({
       contactUsURL,
     }),
+    parentKey: 'ourWorkPage',
   },
 ];


### PR DESCRIPTION
### Motivation

- Fixes #636, #637 

Navigation items were not highlighted correctly, when a child was active. Affected pages:

- Hightlight "Events" when a specified event is active.
- Hightlight "Job" when a specified job is active.
- Hightlight "About us" / "Out team" when a specified person is active.
- Hightlight "What we do" / "Out work" when a specified case study is active.

![navigation-highlighted-correctly](https://user-images.githubusercontent.com/3579251/33990537-3b5745cc-e0c3-11e7-905c-bf2b7db3fa50.png)

### Test plan

- Go to the pages listed above and check, if the correct navigation items are highlighed.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
