### PR TITLE
Use Link components instead of a tags

### DIFF
--- a/site/pages/our-work/case-study-camden-slice/index.js
+++ b/site/pages/our-work/case-study-camden-slice/index.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import styles from './style.css';
+import Link from '../../../components/link';
 
 import camdenLogo from './images/camden_market.png';
 import camdenProjectScreenshot from './images/camden.png';
-
-const caseStudyUrl = '/our-work/case-study/camden-market/';
 
 export default () => (
   <div className={styles.caseStudyContainer}>
     <div className={styles.caseStudyContent}>
       <div className={styles.caseStudyTextContainer}>
-        <a href={caseStudyUrl}>
+        <Link to="camdenMarketCaseStudy">
           <img src={camdenLogo} className={styles.camdenLogo} alt="Camden Market logo" />
           <h2 className={styles.caseStudyTextContainerHeader}>
             Taking steps towards a digital future
@@ -23,11 +22,11 @@ export default () => (
           <div className={styles.links}>
             <p className={styles.readmore}>Read more</p>
           </div>
-        </a>
+        </Link>
       </div>
-      <a className={styles.imageLink} href={caseStudyUrl}>
+      <Link to="camdenMarketCaseStudy" className={styles.imageLink}>
         <img src={camdenProjectScreenshot} alt="Camden project screenshot" />
-      </a>
+      </Link>
     </div>
   </div>
 );

--- a/site/pages/our-work/case-study-cell/index.js
+++ b/site/pages/our-work/case-study-cell/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames/bind';
-
+import Link from '../../../components/link';
 import styles from './style.css';
 
 const cx = classnames.bind(styles);
@@ -11,7 +11,7 @@ type CaseStudyCellProps = {
   [image: string]: any,
   [headerText: string]: any,
   [descriptionText: string]: any,
-  [linkUrl: string]: any,
+  [routeKey: string]: any,
 };
 
 export default function CaseStudyCell(props: CaseStudyCellProps) {
@@ -19,7 +19,7 @@ export default function CaseStudyCell(props: CaseStudyCellProps) {
     <div className={cx('cell', `cell-${props.clientName}`)}>
       <div className={styles.caseStudyContentContainer}>
         <div className={styles.caseStudyContent}>
-          <a href={props.linkUrl}>
+          <Link to={props.routeKey}>
             {/* eslint-disable react/jsx-indent-props, react/jsx-closing-bracket-location */
             /*
               This needs to be disabled due to the way prettier integrates with ESLint at the moment
@@ -50,7 +50,7 @@ export default function CaseStudyCell(props: CaseStudyCellProps) {
             <div className={styles.links}>
               <p className={styles.readmore}>Read more</p>
             </div>
-          </a>
+          </Link>
         </div>
       </div>
     </div>
@@ -63,5 +63,5 @@ CaseStudyCell.propTypes = {
   image: PropTypes.string,
   headerText: PropTypes.string.isRequired,
   descriptionText: PropTypes.string.isRequired,
-  linkUrl: PropTypes.string.isRequired,
+  routeKey: PropTypes.string.isRequired,
 };

--- a/site/pages/our-work/case-study-fortnum-and-mason-slice/index.js
+++ b/site/pages/our-work/case-study-fortnum-and-mason-slice/index.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import styles from './style.css';
+import Link from '../../../components/link';
 
 import fmLogo from './images/fortnum-mason-logo.png';
 import fmProjectSnapshot from './images/fortnum.png';
 import fmProjectMediumSnapshot from './images/fortnum-medium.png';
 
-const caseStudyUrl = '/our-work/case-study/fortnum-and-mason/';
-
 export default () => (
   <div className={styles.caseStudyContainer}>
     <div className={styles.caseStudyContent}>
       <div className={styles.caseStudyTextContainer}>
-        <a href={caseStudyUrl}>
+        <Link to="fortnumAndMasonCaseStudy">
           <img src={fmLogo} className={styles.clientLogo} alt="Fortnum and Mason logo" />
           <h2 className={styles.caseStudyTextContainerHeader}>
             Fortnum & Mason’s new, elegant website increases revenue and conversion rates
@@ -23,9 +22,9 @@ export default () => (
           <div className={styles.links}>
             <p className={styles.readmore}>Read more</p>
           </div>
-        </a>
+        </Link>
       </div>
-      <a className={styles.imageLink} href={caseStudyUrl}>
+      <Link to="fortnumAndMasonCaseStudy" className={styles.imageLink}>
         <img
           className={styles.projectBigSmallSnapshot}
           src={fmProjectSnapshot}
@@ -36,7 +35,7 @@ export default () => (
           src={fmProjectMediumSnapshot}
           alt="Fortnum and Mason project snapshot"
         />
-      </a>
+      </Link>
     </div>
   </div>
 );

--- a/site/pages/our-work/case-study-ft-slice/index.js
+++ b/site/pages/our-work/case-study-ft-slice/index.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import styles from './style.css';
+import Link from '../../../components/link';
 
 import ftLogo from './images/ft-logo.png';
 import ftProjectImage from './images/meeting.png';
-
-const caseStudyUrl = '/our-work/case-study/financial-times/';
 
 export default () => (
   <div className={styles.caseStudyContainer}>
     <div className={styles.caseStudyContent}>
       <div className={styles.caseStudyTextContainer}>
-        <a href={caseStudyUrl}>
+        <Link to="financialTimesCaseStudy">
           <img src={ftLogo} className={styles.clientLogo} alt="Financial Times logo" />
           <h2 className={styles.caseStudyTextContainerHeader}>Lasting change for a media giant</h2>
           <p className={styles.description}>
@@ -21,11 +20,11 @@ export default () => (
           <div className={styles.links}>
             <p className={styles.readmore}>Read more</p>
           </div>
-        </a>
+        </Link>
       </div>
-      <a className={styles.imageLink} href={caseStudyUrl}>
+      <Link to="financialTimesCaseStudy" className={styles.imageLink}>
         <img src={ftProjectImage} alt="Financial Times project snapshot" />
-      </a>
+      </Link>
     </div>
   </div>
 );

--- a/site/pages/our-work/case-study-sky-slice/index.js
+++ b/site/pages/our-work/case-study-sky-slice/index.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import styles from './style.css';
+import Link from '../../../components/link';
 
 import skyLogo from './images/sky.png';
-
-const caseStudyUrl = '/our-work/case-study/sky-cms/';
 
 export default function CaseStudySkySlice() {
   return (
     <div className={styles.caseStudyContainer}>
       <div className={styles.caseStudyContent}>
         <div className={styles.caseStudyTextContainer}>
-          <a href={caseStudyUrl}>
+          <Link to="skyCMSCaseStudy">
             <img src={skyLogo} className={styles.clientLogo} alt="Sky logo" />
             <h2 className={styles.caseStudyTextContainerHeader}>
               A modern CMS that is the foundation that supports both customers and the internal team
@@ -21,7 +20,7 @@ export default function CaseStudySkySlice() {
             <div className={styles.links}>
               <p className={styles.readmore}>Read more</p>
             </div>
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/site/pages/our-work/index.js
+++ b/site/pages/our-work/index.js
@@ -54,7 +54,7 @@ export default function CaseStudies() {
                 descriptionText={
                   'Red Badger teamed up with the Haller Foundation on a pro-bono basis to develop a mobile application which helps Kenyan farmers.'
                 }
-                linkUrl={'/our-work/case-study/haller/'}
+                routeKey="hallerCaseStudy"
               />
               <CaseStudyCell
                 clientName={'BMW'}
@@ -64,7 +64,7 @@ export default function CaseStudies() {
                 descriptionText={
                   'Pushing the boundaries of HTML5 technology to deliver a multi-platform 3D tour of the BMW Museum.'
                 }
-                linkUrl={'/our-work/case-study/bmw/'}
+                routeKey="bmwCaseStudy"
               />
             </div>
             <div className={styles.gridRow}>
@@ -75,7 +75,7 @@ export default function CaseStudies() {
                 descriptionText={
                   'How the rapid prototyping model helped the BBC to uncover new ways to engage its audience.'
                 }
-                linkUrl={'/our-work/case-study/bbc-now/'}
+                routeKey="bbcCaseStudy"
               />
               <CaseStudyCell
                 clientName={'Sky'}
@@ -84,7 +84,7 @@ export default function CaseStudies() {
                 descriptionText={
                   'Enabling Sky to deliver continual improvement across customer services'
                 }
-                linkUrl={'/our-work/case-study/sky/'}
+                routeKey="skyCaseStudy"
               />
             </div>
           </div>


### PR DESCRIPTION
### Motivation

In the staging environment, links to case studies would not keep the commit hash in their URL, thereby subtly breaking the routing behaviour. 

For example when on https://www-staging.red-badger.com/abcdef11/our-work and clicking on the case study for Fortnum & Mason, it would link to https://www-staging.red-badger.com/our-work/case-study/fortnum-and-mason (so removing the commit sha and therefore the user would not see the deployed code that she might expect to see).

This PR switches out the relevant `a` HTML tags with `Link` components which retain routes via the `StateNavigator`.

We came across this while implementing a link in https://github.com/redbadger/website-honestly/pull/635

### Test plan

- Visit https://www-staging.red-badger.com/998c879/our-work and check that _all_ case studies still link correctly and retain the commit sha

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [x] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
