### PR TITLE
Update sky case studies links

### DIFF
--- a/site/components/case-study-overview/index.js
+++ b/site/components/case-study-overview/index.js
@@ -59,11 +59,7 @@ const CaseStudyOverview = () => (
           </span>
           <img alt="The logo of Camden Market" src={camdenPNG} className={styles.logo} />
         </a>
-        <a
-          href="/our-work/case-study/sky-cms"
-          className={styles.figureLink}
-          title="Sky content management system case study"
-        >
+        <a href="/our-work/case-study/sky" className={styles.figureLink} title="Sky case study">
           <InlineSVG src={skyFigureSVG} className={styles.caseFigure} />
           <span className={styles.screenReaderText}>50%</span>
           <span className={styles.caseText}>

--- a/site/pages/our-work/case-study/sky/index.js
+++ b/site/pages/our-work/case-study/sky/index.js
@@ -70,6 +70,9 @@ const SkyCaseStudy = ({ contactUsURL }: CaseStudySkyProps) => (
               {
                 label: 'Serviced half a million customers to date',
               },
+              {
+                label: "50% Drop in customers pushing the 'need more help' button",
+              },
             ]}
             itemClassName={styles.listBox__item}
             labelClassName={styles.listBox__label}

--- a/site/pages/our-work/index.js
+++ b/site/pages/our-work/index.js
@@ -47,6 +47,26 @@ export default function CaseStudies() {
           <div className={styles.grid}>
             <div className={styles.gridRow}>
               <CaseStudyCell
+                clientName={'BBC'}
+                clientLogo={BbcLogo}
+                headerText={'Delivering a better customer experience, faster'}
+                descriptionText={
+                  'How the rapid prototyping model helped the BBC to uncover new ways to engage its audience.'
+                }
+                routeKey="bbcCaseStudy"
+              />
+              <CaseStudyCell
+                clientName={'Sky'}
+                clientLogo={SkyLogo}
+                headerText={'Helping customers help themselves'}
+                descriptionText={
+                  'Enabling Sky to deliver continual improvement across customer services'
+                }
+                routeKey="skyCaseStudy"
+              />
+            </div>
+            <div className={styles.gridRow}>
+              <CaseStudyCell
                 clientName={'Haller'}
                 clientLogo={HallerLogo}
                 image={HallerImage}
@@ -65,26 +85,6 @@ export default function CaseStudies() {
                   'Pushing the boundaries of HTML5 technology to deliver a multi-platform 3D tour of the BMW Museum.'
                 }
                 routeKey="bmwCaseStudy"
-              />
-            </div>
-            <div className={styles.gridRow}>
-              <CaseStudyCell
-                clientName={'BBC'}
-                clientLogo={BbcLogo}
-                headerText={'Delivering a better customer experience, faster'}
-                descriptionText={
-                  'How the rapid prototyping model helped the BBC to uncover new ways to engage its audience.'
-                }
-                routeKey="bbcCaseStudy"
-              />
-              <CaseStudyCell
-                clientName={'Sky'}
-                clientLogo={SkyLogo}
-                headerText={'Helping customers help themselves'}
-                descriptionText={
-                  'Enabling Sky to deliver continual improvement across customer services'
-                }
-                routeKey="skyCaseStudy"
               />
             </div>
           </div>


### PR DESCRIPTION
### Motivation

We want to update a couple of things related to the Sky case studies:

- Link to the Sky case study instead of the Sky CMS case study from the home page
- Add an extra result for the Sky case study (about 50% drop in 'need more help' button clicking)
- Switch the order of CaseStudyCells on the 'our work' page

### Test plan

- Visit https://www-staging.red-badger.com/f51cd98 and check that Sky example links to the Sky case study (not the Sky CMS case study)
- Visit https://www-staging.red-badger.com/f51cd98/our-work/case-study/sky/ and check that extra Results about 50% drop is showing
- Visit https://www-staging.red-badger.com/f51cd98/our-work and check that the CaseStudyCells for BBC and Sky are now on top of Haller and BMW

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
