### PR TITLE
Add HSBC logo to our work page

### DIFF
--- a/site/pages/our-work/client-logos-slice/index.js
+++ b/site/pages/our-work/client-logos-slice/index.js
@@ -11,6 +11,7 @@ import fnfLogo from './images/f_f.png';
 import ftLogo from './images/ft.png';
 import fortnumLogo from './images/fortnum-mason-logo.png';
 import hallerLogo from './images/haller.png';
+import hsbcLogo from './images/hsbc.png';
 import lloydsLogo from './images/lloyds.png';
 import selfridgesLogo from './images/selfridges.png';
 import skyLogo from './images/sky.png';
@@ -21,6 +22,7 @@ export default function ClientLogosSlice() {
   return (
     <div className={styles.caseStudyContainer}>
       <div className={styles.caseStudyContent}>
+        <img src={hsbcLogo} className={styles.hsbcLogo} alt="HSBC logo" />
         <img src={camdenLogo} className={styles.camdenLogo} alt="Camden Market logo" />
         <img src={ftLogo} className={styles.ftLogo} alt="Financial Times logo" />
         <img src={fortnumLogo} className={styles.fortnumLogo} alt="Fortnum and Mason logo" />

--- a/site/pages/our-work/client-logos-slice/style.css
+++ b/site/pages/our-work/client-logos-slice/style.css
@@ -79,6 +79,10 @@
   width: 55px;
 }
 
+.hsbcLogo {
+  width: 100px;
+}
+
 @media mediumScreen {
   .caseStudyContent {
     flex-direction: row;
@@ -154,5 +158,9 @@
 
   .fnfLogo {
     height: 64px;
+  }
+
+  .hsbcLogo {
+    width: 120px;
   }
 }


### PR DESCRIPTION
### Motivation

Add the HSBC logo to the logos slice on 'our work' page

### Test plan

- Visit https://www-staging.red-badger.com/c99a0a5/our-work and check that HSBC logo looks correct in terms of positioning and size

### Screenshots

#### Before:

![screen shot 2017-12-15 at 14 48 08](https://user-images.githubusercontent.com/5112255/34047360-efaeaf26-e1a7-11e7-85ca-58a299c4bc0e.png)

#### After:

![screen shot 2017-12-15 at 14 47 55](https://user-images.githubusercontent.com/5112255/34047359-ef9285a8-e1a7-11e7-9789-68c1bc559c75.png)


### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [x] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
