### PR TITLE
Increase publish service memory size to 2048

### DIFF
--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -30,6 +30,7 @@ functions:
   publish:
     handler: index.publish
     timeout: 60
+    memorySize: 2048
     events:
       - http:
           path: publish


### PR DESCRIPTION
### Motivation

After fixing the item limit in badger brain (https://github.com/redbadger/badger-brain/pull/113), our publishing stopped working. The increased number of generated static html pages (events went from 100 capped to 150) caused the lambda function to hit its memory limit.

The quick fix just increases the memory limit. We should think about reducing the memory usage of the publish service in the future.

### Test plan

- When the Circle CI deployment succeeds, everyting is fine.
