### PR TITLE
Improve performance by lazy loading state

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,14 +1,13 @@
 import 'es6-promise/auto';
 import 'whatwg-fetch';
 
-import decode from 'ent/decode';
 import { makeApp } from '../site/client';
 
 const element = document.querySelector('.js-app');
+const stateHash = document.getElementById('state-hash').value;
 
-const state = JSON.parse(
-  document.getElementById('state').value,
-  (key, value) => (typeof value === 'string' ? decode(value) : value),
-);
-
-makeApp({ element, state }).start();
+fetch(`/state-${stateHash}.json`)
+  .then(response => response.json())
+  .then(state => {
+    makeApp({ element, state }).start();
+  });

--- a/client/index.js
+++ b/client/index.js
@@ -6,7 +6,7 @@ import { makeApp } from '../site/client';
 const element = document.querySelector('.js-app');
 const stateHash = document.getElementById('state-hash').value;
 
-fetch(`/state-${stateHash}.json`)
+fetch(`/${process.env.URL_BASENAME || ''}state-${stateHash}.json`)
   .then(response => response.json())
   .then(state => {
     makeApp({ element, state }).start();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "date-fns": "^1.3.0",
     "deep-extend": "^0.4.1",
     "empty": "^0.10.1",
-    "ent": "^2.2.0",
     "enzyme": "^2.4.1",
     "es6-promise": "^4.0.5",
     "es6-promisify": "^5.0.0",

--- a/services/s3/index.js
+++ b/services/s3/index.js
@@ -6,13 +6,14 @@ export function makeUploader({ bucketName }) {
     region: 'eu-west-1',
   });
 
-  return ({ path, body }) =>
+  return ({ path, body, contentType, cacheControl }) =>
     s3
       .putObject({
         Bucket: bucketName,
         Key: path,
         Body: body,
-        ContentType: 'text/html',
+        ContentType: contentType,
+        CacheControl: cacheControl,
       })
       .promise();
 }

--- a/site/compiler/index.js
+++ b/site/compiler/index.js
@@ -69,8 +69,11 @@ export const expandRoutes = (state, stateNavigator) => {
 export function compileRoutes(state) {
   const stateNavigator = createStateNavigator();
 
-  const encodedState = state && JSON.stringify(state);
   const stateHash = Date.now();
+  const stateFile = {
+    body: state ? JSON.stringify(state) : '{}',
+    path: `${process.env.URL_BASENAME || ''}state-${stateHash}.json`,
+  };
 
   const compile = route => {
     const path = (process.env.URL_BASENAME || '') + route.filePath;
@@ -99,12 +102,9 @@ export function compileRoutes(state) {
     return { body, path };
   };
 
-  const pages = expandRoutes(state, stateNavigator).map(compile);
+  const routeFiles = expandRoutes(state, stateNavigator).map(compile);
 
-  return [
-    { body: encodedState, path: `state-${stateHash}.json` },
-    ...pages,
-  ];
+  return [stateFile, ...routeFiles];
 }
 
 export function compileSite(state) {

--- a/site/compiler/test.js
+++ b/site/compiler/test.js
@@ -2,7 +2,7 @@ import createStateNavigator from '../routes';
 import { expandRoutes } from '.';
 
 describe('site/compiler', () => {
-  describe('compileSite', () => {
+  describe('expandRoutes', () => {
     it('renders all the static pages of the site', () => {
       const routes = expandRoutes(
         {

--- a/site/index.ejs
+++ b/site/index.ejs
@@ -81,7 +81,7 @@
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
-    <input id="state" type="hidden" value="<%= typeof state !== 'undefined' ? state : '{}' %>">
+    <input id="state-hash" type="hidden" value="<%= stateHash %>">
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
   </body>
 </html>


### PR DESCRIPTION
### Motivation

Currently our website is really big (133KB gzipped, 274KB on production).

![Browser with dev tools, showing download size of website](https://user-images.githubusercontent.com/3579251/34167746-7b6864f0-e4da-11e7-89fd-c91d0edde971.png)

This is mainly due the whole state being hydrated in a hidden input field. The same state is present on every page and is therefore loaded every time you visit a different url in a new tab.

I played around with lazy loading the state using JavaScript. This way:

- If JavaScript is disabled, the state is not loaded at all. The page still renders fine.
- Otherwise the state is lazy loaded from `/state.json`. This path is the same for all sites. So if you load another page in another tab, the browser can use the cached json file.

As you can see the site is a lot smaller now (32KB gzipped + 92KB lazy loaded state).

![Browser with dev tools, showing a smaller download size of website](https://user-images.githubusercontent.com/3579251/34169211-8d64828e-e4de-11e7-8c0b-f5eebdf40c5a.png)

### Test plan

- Open the site on all listed devices.
- Make sure it loads correctly and links are working.
- On desktop check for errors in browser console.

### Pre-merge checklist

- [x] Documentation
- [x] Reviews
  - [x] Code review
- [x] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [x] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [ ] Tester approved
