### PR TITLE
Increase node version used by lambdas

### DIFF
--- a/services/serverless.yaml
+++ b/services/serverless.yaml
@@ -10,7 +10,7 @@ provider:
   name: aws
   stage: dev
   region: eu-west-1
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   iamRoleStatements:
     - Effect: "Allow"
       Action:


### PR DESCRIPTION
### Motivation

The serverless config specifies the node version used by AWS Lambda. This version is very old

