### PR TITLE
Reduce circleci node version to match AWS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 machine:
   node:
-    version: 6.11.2
+    version: 6.10
   environment:
-    YARN_VERSION: 0.27.5
+    YARN_VERSION: 1.3.2
     PATH: "${PATH}:${HOME}/.yarn/bin"
     ENVIRONMENT_NAME: staging
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.10
+    version: 6.10.3
   environment:
     YARN_VERSION: 1.3.2
     PATH: "${PATH}:${HOME}/.yarn/bin"


### PR DESCRIPTION
### Motivation

Match node version used by CircleCI with the version used by serverless for AWS lambdas