### PR TITLE
Fix index.ejs for local development

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -81,7 +81,7 @@
     <div class="js-app">
       <% if (typeof bodyContent !== 'undefined') { %><%= bodyContent %><% } %>
     </div>
-    <input id="state-hash" type="hidden" value="<%= stateHash %>">
+    <input id="state-hash" type="hidden" value="<%= typeof stateHash !== 'undefined' ? stateHash : 'none' %>">
     <% if (typeof jsPath !== 'undefined') { %><script type="text/javascript" src="<%= jsPath %>"></script><% } %>
   </body>
 </html>


### PR DESCRIPTION
### Motivation

State lazy loading accidentally broke the local development experience. Locally the state is retrieved differently and there is no `stateHash` inserted into the index.html.