### PR TITLE
Remove duplicated events, jobs and badgers in state.json

### DIFF
--- a/site/compiler/people.test.js
+++ b/site/compiler/people.test.js
@@ -4,14 +4,15 @@ import { expandRoutes } from '.';
 describe('site/compiler', () => {
   const baseState = {
     jobs: [],
-    job: {},
+    jobLookup: {},
     contactUsURL: '',
     featuredBlogPosts: [],
     events: [],
-    event: {},
+    eventLookup: {},
     instagramPosts: [],
     tweets: [],
-    badger: {},
+    badgers: [],
+    badgerLookup: {},
   };
 
   describe('compileSite', () => {
@@ -32,7 +33,7 @@ describe('site/compiler', () => {
           ...baseState,
           badgers: [a],
           categories,
-          badger: { [a.slug]: a },
+          badgerLookup: { [a.slug]: 0 },
         },
         createStateNavigator(),
       );
@@ -70,9 +71,9 @@ describe('site/compiler', () => {
           {
             ...baseState,
             badgers: [a, s],
-            badger: {
-              [a.slug]: a,
-              [s.slug]: s,
+            badgerLookup: {
+              [a.slug]: 0,
+              [s.slug]: 1,
             },
             categories,
           },
@@ -102,7 +103,7 @@ describe('site/compiler', () => {
           {
             ...baseState,
             badgers: [s],
-            badger: { [s.slug]: s },
+            badgerLookup: { [s.slug]: 0 },
             categories,
           },
           createStateNavigator(),
@@ -125,7 +126,7 @@ describe('site/compiler', () => {
         ];
 
         const badgers = [];
-        const badger = {};
+        const badgerLookup = {};
 
         for (let i = 0; i < 20; i += 1) {
           const a = {
@@ -134,7 +135,7 @@ describe('site/compiler', () => {
             categories,
           };
           badgers.push(a);
-          badger[a.slug] = a;
+          badgerLookup[a.slug] = i;
         }
         const e = {
           firstName: 'Etiene',
@@ -145,7 +146,7 @@ describe('site/compiler', () => {
           {
             ...baseState,
             badgers: badgers.push(e) && badgers,
-            badger: { ...badger, [e.slug]: e },
+            badgerLookup: { ...badgerLookup, [e.slug]: badgers.indexOf(e) },
             categories,
           },
           createStateNavigator(),
@@ -166,7 +167,7 @@ describe('site/compiler', () => {
     describe('with 20 Engineers', () => {
       it('should render two everyone pages, including advert, and one for engineering', () => {
         const badgers = [];
-        const badger = {};
+        const badgerLookup = {};
         const categories = [{ name: 'Engineering', slug: 'engineering' }];
         for (let i = 0; i < 20; i += 1) {
           const a = {
@@ -175,13 +176,13 @@ describe('site/compiler', () => {
             categories,
           };
           badgers.push(a);
-          badger[a.slug] = a;
+          badgerLookup[a.slug] = i;
         }
         const routes = expandRoutes(
           {
             ...baseState,
             badgers,
-            badger,
+            badgerLookup,
             categories,
           },
           createStateNavigator(),
@@ -201,7 +202,7 @@ describe('site/compiler', () => {
   describe('with 19 Engineers', () => {
     it('should render one everyone pages, even including advert, and one for engineering', () => {
       const badgers = [];
-      const badger = {};
+      const badgerLookup = {};
       const categories = [{ name: 'Engineering', slug: 'engineering' }];
       for (let i = 0; i < 19; i += 1) {
         const a = {
@@ -210,13 +211,13 @@ describe('site/compiler', () => {
           categories,
         };
         badgers.push(a);
-        badger[a.slug] = a;
+        badgerLookup[a.slug] = i;
       }
       const routes = expandRoutes(
         {
           ...baseState,
           badgers,
-          badger,
+          badgerLookup,
           categories,
         },
         createStateNavigator(),
@@ -234,7 +235,7 @@ describe('site/compiler', () => {
   describe('with 41 Engineers and Leaderships', () => {
     it('should render three everyone pages and three for engineering and three for leadership', () => {
       const badgers = [];
-      const badger = {};
+      const badgerLookup = {};
       const categories = [
         { name: 'Engineering', slug: 'engineering' },
         { name: 'Leadership', slug: 'leadership' },
@@ -246,13 +247,13 @@ describe('site/compiler', () => {
           categories,
         };
         badgers.push(a);
-        badger[a.slug] = a;
+        badgerLookup[a.slug] = i;
       }
       const routes = expandRoutes(
         {
           ...baseState,
           badgers,
-          badger,
+          badgerLookup,
           categories,
         },
         createStateNavigator(),
@@ -276,7 +277,7 @@ describe('site/compiler', () => {
   describe('with 41 Engineers and 21 Leaderships', () => {
     it('should render three everyone pages and three for engineering and two for leadership', () => {
       const badgers = [];
-      const badger = {};
+      const badgerLookup = {};
       const categories = [
         { name: 'Engineering', slug: 'engineering' },
         { name: 'Leadership', slug: 'leadership' },
@@ -288,7 +289,7 @@ describe('site/compiler', () => {
           categories,
         };
         badgers.push(a);
-        badger[a.slug] = a;
+        badgerLookup[a.slug] = i;
       }
       for (let i = 21; i < 41; i += 1) {
         const a = {
@@ -297,13 +298,13 @@ describe('site/compiler', () => {
           categories: [categories[0]],
         };
         badgers.push(a);
-        badger[a.slug] = a;
+        badgerLookup[a.slug] = badgers.indexOf(a);
       }
       const routes = expandRoutes(
         {
           ...baseState,
           badgers,
-          badger,
+          badgerLookup,
           categories,
         },
         createStateNavigator(),
@@ -339,7 +340,7 @@ describe('site/compiler', () => {
           ...baseState,
           badgers: [a],
           categories,
-          badger: { [a.slug]: a },
+          badgerLookup: { [a.slug]: 0 },
         },
         createStateNavigator(),
       );
@@ -371,9 +372,9 @@ describe('site/compiler', () => {
           ...baseState,
           badgers: [a, s],
           categories,
-          badger: {
-            [a.slug]: a,
-            [s.slug]: s,
+          badgerLookup: {
+            [a.slug]: 0,
+            [s.slug]: 1,
           },
         },
         createStateNavigator(),

--- a/site/compiler/test.js
+++ b/site/compiler/test.js
@@ -7,12 +7,13 @@ describe('site/compiler', () => {
       const routes = expandRoutes(
         {
           jobs: [],
-          job: {},
+          jobLookup: {},
           contactUsURL: '',
           featuredBlogPosts: [],
           events: [],
-          event: {},
+          eventLookup: {},
           badgers: [],
+          badgerLookup: {},
           categories: [],
           instagramPosts: [],
           tweets: [],
@@ -52,15 +53,16 @@ describe('site/compiler', () => {
       const routes = expandRoutes(
         {
           jobs: [softwareEngineer, uxDesinger],
-          job: {
-            'software-engineer': softwareEngineer,
-            'ux-designer': uxDesinger,
+          jobLookup: {
+            'software-engineer': 0,
+            'ux-designer': 1,
           },
           contactUsURL: '',
           featuredBlogPosts: [],
           events: [],
-          event: {},
+          eventLookup: {},
           badgers: [],
+          badgerLookup: {},
           categories: [],
           instagramPosts: [],
           tweets: [],
@@ -80,7 +82,7 @@ describe('site/compiler', () => {
       const routes = expandRoutes(
         {
           jobs: [],
-          job: {},
+          jobLookup: {},
           contactUsURL: '',
           featuredBlogPosts: [
             {
@@ -95,8 +97,9 @@ describe('site/compiler', () => {
             },
           ],
           events: [],
-          event: {},
+          eventLookup: {},
           badgers: [],
+          badgerLookup: {},
           categories: [],
           instagramPosts: [],
           tweets: [],
@@ -148,15 +151,16 @@ describe('site/compiler', () => {
       const routes = expandRoutes(
         {
           jobs: [],
-          job: {},
+          jobLookup: {},
           contactUsURL: '',
           featuredBlogPosts: [],
           events: [upcomingEvent, designingEvent],
-          event: {
-            'upcoming-event': upcomingEvent,
-            'designing-in-cross-functional-teams': designingEvent,
+          eventLookup: {
+            'upcoming-event': 0,
+            'designing-in-cross-functional-teams': 1,
           },
           badgers: [],
+          badgerLookup: {},
           categories: [],
           instagramPosts: [],
           tweets: [],

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -54,7 +54,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     title: ({ job }) => job.title,
     key: 'job',
     route: 'jobs/{slug}',
-    stateToProps: (state, params = {}) => ({ job: state.job[params.slug] }),
+    stateToProps: (state, params = {}) => ({ job: state.jobs[state.jobLookup[params.slug]] }),
     gen: state => state.jobs.map(({ slug }) => ({ slug })),
     parentKey: 'joinUs',
   },
@@ -68,7 +68,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     title: ({ event }) => event.title,
     key: 'event',
     route: 'events/{year}/{month}/{date}/{slug}',
-    stateToProps: (state, params = {}) => ({ event: state.event[params.slug] }),
+    stateToProps: (state, params = {}) => ({ event: state.events[state.eventLookup[params.slug]] }),
     gen: state =>
       state.events.map(({ startDateTime: { date, month, year }, slug }) => ({
         date,
@@ -92,7 +92,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     key: 'badger',
     route: 'people/{slug}',
     stateToProps: (state, params = {}) => ({
-      badger: state.badger[params.slug],
+      badger: state.badgers[state.badgerLookup[params.slug]],
     }),
     gen: state => state.badgers.map(({ slug }) => ({ slug })),
     parentKey: 'badgers',

--- a/state/index.js
+++ b/state/index.js
@@ -10,11 +10,11 @@ const initialState = {
   contactUsURL: process.env.CONTACT_US_SERVICE_URL,
 };
 
-const toDict = (array, keyFn) =>
+const toLookupDict = (array, keyFn) =>
   array.reduce(
-    (obj, item) => ({
+    (obj, item, index) => ({
       ...obj,
-      [keyFn(item)]: item,
+      [keyFn(item)]: index,
     }),
     {},
   );
@@ -31,11 +31,11 @@ const getSiteState = () =>
     ...initialState,
   }).then(({ data: { events, badgers, categories, qAndAs }, ...state }) => ({
     ...state,
-    job: toDict(state.jobs, j => j.slug),
+    jobLookup: toLookupDict(state.jobs, j => j.slug),
     events,
-    event: toDict(events, e => e.slug),
+    eventLookup: toLookupDict(events, e => e.slug),
     badgers,
-    badger: toDict(badgers, b => b.slug),
+    badgerLookup: toLookupDict(badgers, b => b.slug),
     categories,
     qAndAs,
   }));


### PR DESCRIPTION
### Motivation

I noticed that all events, jobs and badgers were included twice in our `state.json` file. This nearly doubled the size without providing any benefits.

This removes all the duplicates, reducing the file size on staging from 347KB (91KB gzipped) to 183KB (53KB gzipped).

### Test plan

- Visit all pages and make sure they load without errors (with and without JavaScript).

### Pre-merge checklist

- [x] Reviews
  - [x] Code review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

  