### PR TITLE
Fix layout of browser not supported page for IE 8 & 9

### DIFF
--- a/site/index.ejs
+++ b/site/index.ejs
@@ -29,9 +29,9 @@
     <script type="text/javascript">
         var uaSniffer = new UAParser();
         var browser = uaSniffer.getBrowser();
-        if ( window.location.pathname !== '/browser-not-supported/' ) {
+        if ( window.location.pathname !== '/<%= process.env.URL_BASENAME || '' %>browser-not-supported/' ) {
             if ( browser.name === 'IE' && browser.major < 10 ) {
-                window.location.pathname = '/browser-not-supported';
+                window.location.pathname = '/<%= process.env.URL_BASENAME || '' %>browser-not-supported/';
             }
         }
     </script>

--- a/site/pages/browser-not-supported/index.js
+++ b/site/pages/browser-not-supported/index.js
@@ -8,74 +8,60 @@ import firefoxImage from './images/firefox.png';
 import safariImage from './images/safari.png';
 import operaImage from './images/opera.png';
 
+const browsers = [
+  {
+    name: 'Chrome',
+    link: 'https://www.google.co.uk/chrome/browser/desktop/index.html',
+    image: chromeImage,
+  },
+  {
+    name: 'Firefox',
+    link: 'https://www.mozilla.org/firefox/',
+    image: firefoxImage,
+  },
+  {
+    name: 'Safari',
+    link: 'https://support.apple.com/en_GB/downloads/safari',
+    image: safariImage,
+  },
+  {
+    name: 'Opera',
+    link: 'https://www.opera.com/',
+    image: operaImage,
+  },
+];
+
 export default function BrowserNotSupported() {
   return (
     <div className={styles.bns__container}>
-      <section className={styles.bns__headerContainer}>
+      <div className={styles.bns__headerContainer}>
         <div className={styles.bns__headerWraper}>
           <h1 className={styles.bns__headerHeadline}>Browser not supported</h1>
           <p className={styles.bns__headerContent}>
             {`Thanks for visiting but we don’t support your browser. Upgrade to one of these to see what we offer.`}
           </p>
         </div>
-      </section>
-      <section className={styles.bns__browsers}>
+      </div>
+      <div className={styles.bns__browsers}>
         <ul>
-          <li>
-            <a
-              className={styles.bns__browserLink}
-              href="https://www.google.co.uk/chrome/browser/desktop/index.html"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <div>
-                <img src={chromeImage} alt="Chrome" />
-              </div>
-              <span>Chrome</span>
-            </a>
-          </li>
-          <li>
-            <a
-              className={styles.bns__browserLink}
-              href="https://www.mozilla.org/firefox/"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <div>
-                <img src={firefoxImage} alt="Firefox" />
-              </div>
-              <span>Firefox</span>
-            </a>
-          </li>
-          <li>
-            <a
-              className={styles.bns__browserLink}
-              href="https://support.apple.com/en_GB/downloads/safari"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <div>
-                <img src={safariImage} alt="Safari" />
-              </div>
-              <span>Safari</span>
-            </a>
-          </li>
-          <li>
-            <a
-              className={styles.bns__browserLink}
-              href="http://www.opera.com/"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <div>
-                <img src={operaImage} alt="Opera" />
-              </div>
-              <span>Opera</span>
-            </a>
-          </li>
+          {browsers.map(browser => (
+            <li>
+              <a
+                className={styles.bns__browserLink}
+                href={browser.link}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                <div>
+                  <img src={browser.image} alt={browser.name} />
+                </div>
+                <span>{browser.name}</span>
+              </a>
+            </li>
+          ))}
         </ul>
-      </section>
-      <section className={styles.bns__footer}>
+      </div>
+      <div className={styles.bns__footer}>
         <div className={styles.bns__footerWraper}>
           <h2 className={styles.bns__footerHeadLine}>
             Need help with digital transformation?<br />Tell us more.
@@ -91,7 +77,7 @@ export default function BrowserNotSupported() {
             </a>
           </p>
         </div>
-      </section>
+      </div>
     </div>
   );
 }

--- a/site/pages/browser-not-supported/style.css
+++ b/site/pages/browser-not-supported/style.css
@@ -41,14 +41,12 @@ body {
   padding: 0;
   margin: 0;
   list-style: none;
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
 }
 
 .bns__browsers li {
   width: 50%;
   margin-bottom: 1.25em;
+  display: inline-block;
 }
 
 .bns__browsers li div  {
@@ -56,14 +54,13 @@ body {
    margin: 0 auto .5em;
 }
 
-
 .bns__browsers img {
   display: block;
   border-radius: 50%;
   margin: 0 auto;
   width: 100%;
+  height: auto;
 }
-
 
 .bns__browserLink {
   text-align: center;
@@ -89,7 +86,6 @@ body {
   margin: 0 auto;
 }
 
-
 .bns__footerHeadLine {
   composes: serif;
   composes: fontM;  
@@ -106,7 +102,6 @@ body {
 }
 
 @media mediumScreen {
-  
   .bns__headerHeadline {
     font-size: 60px;
   }
@@ -135,7 +130,6 @@ body {
   .bns__footer {
     padding: 3.75em 20px 4.375em;
   }
-  
 }
 
 @media largeScreen {
@@ -166,5 +160,4 @@ body {
   .bns__footer {
     padding: 5em 20px 4.375em;
   }
-  
 }

--- a/site/routes/definitions.js
+++ b/site/routes/definitions.js
@@ -9,6 +9,7 @@ type RouteDefinition = {|
   stateToProps?: (state: Object, params?: Object) => any,
   gen?: (state: Object) => Array<Object>,
   parentKey?: string,
+  noLayout?: boolean,
 |};
 
 export const routeDefinitions: Array<RouteDefinition> = [
@@ -207,6 +208,7 @@ export const routeDefinitions: Array<RouteDefinition> = [
     title: 'Browser not supported',
     key: 'browserNotSupported',
     route: 'browser-not-supported',
+    noLayout: true,
   },
   {
     title: 'Camden market case study',

--- a/site/routes/index.js
+++ b/site/routes/index.js
@@ -64,6 +64,10 @@ function routes() {
     ...route,
     component: (routerProps, props) => {
       const Component = componentMap[route.key];
+      if (route.noLayout) {
+        return <Component {...props} />;
+      }
+
       return (
         <L {...routerProps}>
           <Component {...props} />


### PR DESCRIPTION
### Motivation

Fixes #663 

The "Browser not supported" page for IE < 10 didn't look good in IE 8 & 9 (exactly where it should look good 😅). See pictures of before/after this PR:

| Browser | Before | After |
| --- | --- | --- |
| IE 8 | ![ie-8-before](https://user-images.githubusercontent.com/3579251/34563296-09bf8abe-f14a-11e7-8859-f08dcf692966.png) | ![ie-8-after](https://user-images.githubusercontent.com/3579251/34564151-7c2293e6-f14d-11e7-9742-72b9fc4e18f5.png) |
| IE 9 | ![ie-9-before](https://user-images.githubusercontent.com/3579251/34563316-16d66d1c-f14a-11e7-9423-86cea189ba39.png) | ![ie-9-after](https://user-images.githubusercontent.com/3579251/34564156-7fdc8802-f14d-11e7-8b9d-809dcdf206c1.png) |

### Things to note

- I removed the navigation and default footer completely from this page, because it looks broken and links won't work anyway.
- IE 8 does not support responsive layouts, so it always shows the mobile view.
- IE 8 does support `<section>` elements, so I used `<div>` instead.

### Test plan

- Open the site with both IE 8 and IE 9.
- You should be redirected to a "Browser not supported" page.
- The page should look as in the screenshots above.

### Pre-merge checklist

- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 8
  - [x] Windows 7 IE 9
  