### PR TITLE
Fix navigation on homepage for IE10

### DIFF
--- a/site/components/case-study-overview/style.css
+++ b/site/components/case-study-overview/style.css
@@ -45,6 +45,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
+  flex: 0 1 auto; /*Provide all values to avoid IE10 bug with shorthand flex - http://git.io/vllC7*/
 }
 
 .caseFigure svg {
@@ -63,6 +64,8 @@
   text-align: center;
   padding: 30px 0px;
   max-width: 100%;
+  display: block; /*Set to avoid IE10 bug with non-wrapping text*/
+  flex: 0 1 auto; /*Provide all values to avoid IE10 bug with shorthand flex - http://git.io/vllC7*/
 }
 
 .lastWord {

--- a/site/components/header/style.css
+++ b/site/components/header/style.css
@@ -13,11 +13,13 @@
   width: 100%;
   justify-content: flex-end;
   position: relative;
+  flex: 0 1 auto;  /*Provide all values to avoid IE10 bug with shorthand flex - http://git.io/vllC7*/
 }
 
 .logo {
   width: 140px;
   height: 35px;
+  flex: 0 1 auto;  /*Provide all values to avoid IE10 bug with shorthand flex - http://git.io/vllC7*/
 }
 
 .logo svg {

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,14 +344,14 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.3.tgz#c2841e38b7940c2d0a9bbffd72c75f33637854f8"
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.4.tgz#29b367c03876a29bfd3721260d945e3545666c8d"
   dependencies:
-    browserslist "^2.10.0"
-    caniuse-lite "^1.0.30000783"
+    browserslist "^2.10.2"
+    caniuse-lite "^1.0.30000784"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.14"
+    postcss "^6.0.15"
     postcss-value-parser "^3.2.3"
 
 aws-sdk@^2.3.17:
@@ -1192,12 +1192,12 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserslist@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
+browserslist@^2.10.2:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.0.tgz#50350d6873a82ebe0f3ae5483658c571ae5f9d7d"
   dependencies:
-    caniuse-lite "^1.0.30000780"
-    electron-to-chromium "^1.3.28"
+    caniuse-lite "^1.0.30000784"
+    electron-to-chromium "^1.3.30"
 
 browserslist@~1.4.0:
   version "1.4.0"
@@ -1324,9 +1324,9 @@ caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000578:
   version "1.0.30000597"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000597.tgz#b52e6cbe9dc83669affb98501629feaee1af6588"
 
-caniuse-lite@^1.0.30000780, caniuse-lite@^1.0.30000783:
-  version "1.0.30000784"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz#129ced74e9a1280a441880b6cd2bce30ef59e6c0"
+caniuse-lite@^1.0.30000784:
+  version "1.0.30000789"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz#2e3d937b267133f63635ef7f441fac66360fc889"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1593,14 +1593,18 @@ color-convert@^1.3.0:
     color-name "^1.1.1"
 
 color-convert@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
-color-name@^1.0.0, color-name@^1.1.1:
+color-name@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 color-string@^0.3.0:
   version "0.3.0"
@@ -2504,7 +2508,7 @@ electron-releases@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
 
-electron-to-chromium@^1.3.28:
+electron-to-chromium@^1.3.30:
   version "1.3.30"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
   dependencies:
@@ -6310,7 +6314,7 @@ postcss@^5.0.19:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.14:
+postcss@^6.0.0:
   version "6.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
   dependencies:
@@ -6325,6 +6329,14 @@ postcss@^6.0.1:
     chalk "^2.0.1"
     source-map "^0.5.6"
     supports-color "^4.2.0"
+
+postcss@^6.0.14, postcss@^6.0.15:
+  version "6.0.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
+  dependencies:
+    chalk "^2.3.0"
+    source-map "^0.6.1"
+    supports-color "^5.1.0"
 
 pre-git@^3.10.0:
   version "3.12.0"
@@ -7670,15 +7682,21 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.2.0:
+supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
+supports-color@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^4.2.1, supports-color@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+supports-color@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.1.0.tgz#058a021d1b619f7ddf3980d712ea3590ce7de3d5"
   dependencies:
     has-flag "^2.0.0"
 


### PR DESCRIPTION
### Motivation

[Related issue](https://github.com/redbadger/website-honestly/issues/662)

The navigation was not fully visible on the home page due to a bug in IE10 with flexbox. Also the text wasn't wrapping correctly for the Case studies overview on the homepage (on IE10 only). This PR fixes both issues. The cause seems to be that IE10 implements Flexbox slightly differently in that its defaults for the flex short form are different, and have to be set explicitly to bring them in line with other browsers. See http://git.io/vllC7 for details.

### Screenshots

#### Navigation - Before
![screen shot 2018-01-08 at 17 14 25](https://user-images.githubusercontent.com/5112255/34682655-7896922a-f497-11e7-8c07-2f18a2bda99a.png)

#### Navigation - After
![screen shot 2018-01-08 at 17 14 05](https://user-images.githubusercontent.com/5112255/34682662-7d304538-f497-11e7-9277-f6ee1e45ee6f.png)

#### Case study overview - Before
![screen shot 2018-01-09 at 13 43 04](https://user-images.githubusercontent.com/5112255/34724251-0fb47296-f545-11e7-80ea-8fbee6ee40f2.png)


#### Case study overview - After
![screen shot 2018-01-09 at 13 41 21](https://user-images.githubusercontent.com/5112255/34724263-165148f4-f545-11e7-935c-55918bcc758f.png)

### Test plan

- Open the homepage in IE10 and check that top right navigation menu is visible and that the text wraps correctly.
- Open the homepage in other browsers and check that nothing has changed.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved

  
  
  