### PR TITLE
Add gif to baseServiceConfig asset rule

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -104,7 +104,7 @@ exports.baseServiceConfig = webpackMerge(baseConfig, {
   module: {
     rules: [
       {
-        test: /\.(png|jpe?g|eot|ttf|woff|woff2)$/,
+        test: /\.(png|jpe?g|gif|eot|ttf|woff|woff2)$/,
         exclude: [path.resolve(__dirname, 'dist'), path.resolve(__dirname, 'node_modules')],
         use: [
           {


### PR DESCRIPTION
### Motivation

This makes the rule match the one already defined in the baseConfig config. Previously this was interpreted as a new rule and would cause all assets to be written to /dist/services/assets-honestly. We already save all assets to /dist/assets-honestly via the baseConfig rule so don't need to do it twice.

This fixes the issue that asset URLs were being written into the html source code with wrong file hashes, causing them to 404 on the live site (when not using JavaScript).

Ideally @frigus02 should have a look at this once he's back. In the meantime we should deploy this to fix the 404s on the static site.

### Test plan

- Check the assets load on the site without JS
- Check the assets load on the site with JS
- Check the confused badger image on the 404 page

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
