### PR TITLE
Add retry when fetching content from the blog

### DIFF
--- a/site/fetchers/util/fetch-retry-test.js
+++ b/site/fetchers/util/fetch-retry-test.js
@@ -1,0 +1,59 @@
+import nock from 'nock';
+import { assert } from 'chai';
+
+import fetchRetry from './fetch-retry';
+
+describe('fetch-retry', () => {
+  const expectedUrl = 'http://some-url.com';
+
+  describe('nominal', () => {
+    it('do the fetch call normally', done => {
+      nock(expectedUrl)
+        .get(/.*/)
+        .reply(200, '"Hello World"');
+      fetchRetry(expectedUrl)
+        .then(response => response.json())
+        .then(data => {
+          expect(data).to.equal('Hello World');
+          done();
+        });
+    });
+  });
+
+  describe('when #options.retries=3 (default)', () => {
+    describe('when first call is a failure', () => {
+      beforeEach(() => {
+        nock(expectedUrl)
+          .get(/.*/)
+          .reply(500, '"Oh noooooo"');
+        nock(expectedUrl)
+          .get(/.*/)
+          .reply(200, '"Hello World"');
+      });
+      it('returns the right value', done => {
+        fetchRetry(expectedUrl)
+          .then(response => response.json())
+          .then(data => {
+            expect(data).to.equal('Hello World');
+            done();
+          });
+      });
+    });
+
+    describe('when all calls are a failure', () => {
+      beforeEach(() => {
+        nock(expectedUrl)
+          .get(/.*/)
+          .reply(500, '"Oh noooo"');
+      });
+      it('returns the right value', done => {
+        fetchRetry(expectedUrl, { retryDelay: 1 })
+          .then(response => response.json())
+          .catch(error => {
+            assert.isDefined(error);
+            done();
+          });
+      });
+    });
+  });
+});

--- a/site/fetchers/util/fetch-retry.js
+++ b/site/fetchers/util/fetch-retry.js
@@ -1,0 +1,38 @@
+import fetch from 'node-fetch';
+
+// Code inspired from https://github.com/jonbern/fetch-retry/blob/master/index.js but using node-fetch
+// instead of isomorphic-fetch
+// Another difference is that it retries if the response is not ok
+export default function fetchRetry(url, options) {
+  let retries = 3;
+  let retryDelay = 1000;
+  if (options && options.retries) {
+    retries = options.retries;
+  }
+  if (options && options.retryDelay) {
+    retryDelay = options.retryDelay;
+  }
+  return new Promise((resolve, reject) => {
+    const wrappedFetch = n => {
+      const retryOrRejectCall = error => {
+        if (n > 0) {
+          setTimeout(() => {
+            wrappedFetch(n - 1);
+          }, retryDelay);
+        } else {
+          reject(error);
+        }
+      };
+      fetch(url, options)
+        .then(response => {
+          if (response.ok) {
+            resolve(response);
+          } else {
+            retryOrRejectCall(new Error(`${response.statusText} for request: ${response.url}`));
+          }
+        })
+        .catch(retryOrRejectCall);
+    };
+    wrappedFetch(retries);
+  });
+}


### PR DESCRIPTION
Fetching content from the blog may fails sometimes, with timeout or network errors. We try 3 times before actually throwing an error when retrieving the data.

### Motivation

We discovered that some builds were failing because a network error was happening when contacting https://blog.red-badger.com/blog/?&format=json&tag=tag, restarting the build would fix the problem as the call to retrieve the blog posts would work.
We thought it would be good to programmatically retry to retrieve the blog posts 3 times before failing.

### Test plan

Make sure the blogs posts are being displayed in `/technology`


### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
