### PR TITLE
disable horizontal scroll safari

### DIFF
--- a/site/layout/style.css
+++ b/site/layout/style.css
@@ -9,6 +9,11 @@ html, body {
   position: relative;
 }
 
+html {
+  overflow: hidden;
+  overflow-y: auto;
+}
+
 body {
     overflow-x: hidden;
 }


### PR DESCRIPTION
### Motivation

On iOS you can scroll horizontally showing the edge of the slice.

![kinky bit](https://user-images.githubusercontent.com/1764217/35223051-f9f00578-ff77-11e7-856a-57b3f639fc34.jpg)

The fix here is to disable horizontal scrolling thus giving the same experience already on firefox/chrome.

### Test plan

- https://www-staging.red-badger.com/3ffc797/
- Test on browsers/devices and ensure on mobile viewyou can't scroll horizontally.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
