### PR TITLE
fix yarn cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ dependencies:
       if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
         curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
       fi
+    - mkdir ~/.yarn-cache
   cache_directories:
     - ~/.yarn
     - ~/.yarn-cache


### PR DESCRIPTION
### Motivation

I noticed a warning in CircleCI that the yarn cache wasn't being used, followed advice [here](https://discuss.circleci.com/t/cache-yarn-properly/7429/2).

### Test plan

See that warning present [here](https://circleci.com/gh/redbadger/website-honestly/3175?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) is no longer showing in the build for this [branch](https://circleci.com/gh/redbadger/website-honestly/3176?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
