### PR TITLE
F&M case study - add alt text to main header

### DIFF
--- a/site/pages/our-work/case-study/fortnum-and-mason/index.js
+++ b/site/pages/our-work/case-study/fortnum-and-mason/index.js
@@ -37,6 +37,7 @@ const CaseStudyFortnumAndMason = () => (
         largeSrc={headerImageLarge}
         mediumSrc={headerImageMedium}
         smallSrc={headerImageSmall}
+        alt="Fortnum and Mason logo embellished by gold scrolls"
       />
     </div>
     <div className={styles.content}>


### PR DESCRIPTION
The main header image on the F&M case study page is missing an alt tag. https://red-badger.com/our-work/case-study/fortnum-and-mason

Add alt text "Fortnum and Mason logo embellished by gold scrolls" to the image.
