### PR TITLE
Add missing import statement

### DIFF
--- a/services/mailchimp/update-user/index.js
+++ b/services/mailchimp/update-user/index.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+
+import crypto from 'crypto';
 import { mailchimpApi, formatUpdateResponse, formatFormInput } from '../utilities';
 
 function md5(str) {


### PR DESCRIPTION
### Changes

#### Trello Ticket / Github Issue Link

https://github.com/redbadger/website-honestly/issues/700
https://github.com/redbadger/website-honestly/issues/693

#### Description

Adds a missing import statement. Without it, `crypto` is not included correctly by webpack.

Fixes #700 and #693 

### Test

#### Test plan

Both issues are fixed. This can only be tested on staging or production.
