### PR TITLE
Added secrets scanner, attached to pre-commit, updated readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pids
 assets/state.json
 .idea
 keyrings
+scanner

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,24 @@ dist/static-site:
 	mkdir -p ./dist/static-site
 	@$(PRINT_OK)
 
+scanner: ## Initialize git secrets in the scanner folder
+	git clone git@github.com:redbadger/secrets-scanner.git scanner
+	@echo ""
+	@echo "*************************************************************"
+	@echo "* Follow the instructions to get added to the setup the scanner:"
+	@echo "* https://github.com/redbadger/secrets-scanner/blob/master/README.md"
+	@echo "*************************************************************"
+	@echo ""
+	@read -p "Press any key to continue."
+
+setup-scanner: scanner ## Setup git secrets with stored configuration
+	@cd scanner && git pull
+	@cd scanner && $(MAKE) full-setup
+	@$(PRINT_OK)
+
+scan-secrets: scanner ## Scan for secrets
+	@git secrets --scan
+	@$(PRINT_OK)
 
 .PHONY: \
 	dev \
@@ -196,4 +214,6 @@ dist/static-site:
 	test-watch \
 	sw \
 	update-secrets \
-	edit-secrets
+	edit-secrets \
+	setup-scanner \
+	scan-secrets

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ scanner: ## Initialize git secrets in the scanner folder
 	git clone git@github.com:redbadger/secrets-scanner.git scanner
 	@echo ""
 	@echo "*************************************************************"
-	@echo "* Follow the instructions to get added to the setup the scanner:"
+	@echo "* Follow the instructions below to setup the scanner:"
 	@echo "* https://github.com/redbadger/secrets-scanner/blob/master/README.md"
 	@echo "*************************************************************"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ make keyrings
 # - "Getting Blackbox"
 # - "Get access to existing blackbox secrets"
 
-# Set up the git secrets to scan for secrets pre-commit. Follow the instructions of this command:
+# Set up git secrets to scan for secrets pre-commit. Follow the instructions of this command:
 make scanner
 
 # Go to https://github.com/redbadger/secrets-scanner/blob/master/README.md

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ make keyrings
 # - "Getting Blackbox"
 # - "Get access to existing blackbox secrets"
 
+# Set up the git secrets to scan for secrets pre-commit. Follow the instructions of this command:
+make scanner
+
+# Go to https://github.com/redbadger/secrets-scanner/blob/master/README.md
+# Follow instructions to
+# - "Getting Git Secrets"
+# - "Setting up to scan"
+
 # Fetch and stash dynamic data for development. You might need to do this
 # every time you want to get updated data from staging for local development.
 make fetch

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   "config": {
     "pre-git": {
       "pre-commit": [
+        "make scan-secrets",
         "make prettier",
         "make lint",
         "make test"


### PR DESCRIPTION
### Changes
Adds https://github.com/redbadger/secrets-scanner -> scanner
Adds to makefile to make use of scanner
Adds scan to pre-commit -> package.json
Adds scanner to .gitignore

#### Trello Ticket / Github Issue Link
https://trello.com/c/ZvEYcY4B/123-issue-599-preventing-publishing-of-secret-information
https://github.com/redbadger/website-honestly/issues/599

#### Description
Using https://github.com/redbadger/secrets-scanner, we are able to add a git hook with pre-git to scan for secrets before any accidental commit of said secrets. Patterns are defined within the added repo but can be added project based locally.

### Test
Review needed

#### Can this PR be merged immediately after testing (eg. rebase, infrastructure update)?
Yes

### Docs and training
For reference:
https://github.com/redbadger/secrets-scanner
https://github.com/awslabs/git-secrets
