### PR TITLE
Add microdata from Schema.org to help SEO on events

### DIFF
--- a/site/components/date-bubble/index.js
+++ b/site/components/date-bubble/index.js
@@ -27,7 +27,9 @@ function displayDateContent(startDateTime, endDateTime) {
 }
 
 const DateBubble = ({ startDateTime, endDateTime }: DateBubbleProps) => (
-  <div className={styles.dateBubble}>{displayDateContent(startDateTime, endDateTime)}</div>
+  <div itemProp="startDate" content={startDateTime.iso} className={styles.dateBubble}>
+    {displayDateContent(startDateTime, endDateTime)}
+  </div>
 );
 
 export default DateBubble;

--- a/site/components/event-title/index.js
+++ b/site/components/event-title/index.js
@@ -11,7 +11,7 @@ type EventTitleProps = {
 };
 
 const EventTitle = ({ eventLink, eventTitle }: EventTitleProps) => (
-  <h2 className={styles.eventTitle}>
+  <h2 className={styles.eventTitle} itemProp="name">
     <Link to="event" navigationData={eventLink} className={styles.eventTitleLink}>
       <span>{eventTitle}</span>
     </Link>

--- a/site/pages/event/index.js
+++ b/site/pages/event/index.js
@@ -44,7 +44,7 @@ export default function Event({ event }: EventProps) {
   };
 
   return (
-    <div className={styles.background}>
+    <div className={styles.background} itemScope itemType="http://schema.org/Event">
       <Social {...social} />
       <Section>
         <Container>
@@ -54,7 +54,9 @@ export default function Event({ event }: EventProps) {
               startDateTime={event.startDateTime}
               endDateTime={setEndDate('today', event.startDateTime, event.endDateTime)}
             />
-            <h1 className={styles.eventTitle}>{event.title}</h1>
+            <h1 className={styles.eventTitle} itemProp="name">
+              {event.title}
+            </h1>
             <div className={styles.twoColumn}>
               <div className={styles.event}>
                 <div className={styles.eventDescription}>{event.strapline}</div>

--- a/site/pages/events/events-list-entry/index.js
+++ b/site/pages/events/events-list-entry/index.js
@@ -50,7 +50,12 @@ const EventsListEntry = ({
   };
 
   return (
-    <li key={`entry_${id}`} className={styles.eventItem}>
+    <li
+      key={`entry_${id}`}
+      className={styles.eventItem}
+      itemScope
+      itemType="http://schema.org/Event"
+    >
       <Grid fit={false}>
         <Cell size={12}>
           <HR color="grey" customClassName={styles.mobileHorizontalLine} />


### PR DESCRIPTION
### Changes


#### Description

Microdata is another layer of information to provide web spiders with more meaningful data about our content.

To provide this layer we need to add more html attributes described on  [Schema.org](http://schema.org)

I added event microdata from [Schema.org](http://schema.org/Event) to help SEO on events

#### Can this PR be merged immediately after testing (eg. rebase, infrastructure update)?
Yes

#### Test setup (any additional steps that need to be taken to test the story)

We can test this feature once is in production and exposed to web spiders

At the moment when I searched on Google for `red badger events` I received [this](https://www.google.co.uk/search?q=red+badger+events&oq=red+badger+events) 


#### Does this affect any marketing tests (ie. hubspot scripts)?
Dunno, I guess it would improve

### Docs and training
Would be worth it to check Schema documentation

### Here is a GIF
![](https://media.giphy.com/media/11Mfs7wdWNzJq8/giphy.gif)