### PR TITLE
Add microdata from Schema.org to help SEO on events

### DIFF
--- a/site/components/date-bubble/index.js
+++ b/site/components/date-bubble/index.js
@@ -6,9 +6,10 @@ import styles from './style.css';
 
 export type DateShape = {
   date: string,
+  iso?: string,
+  month?: string,
   monthSym: string,
   year: string,
-  month?: string,
 };
 
 type DateBubbleProps = {

--- a/site/components/date-bubble/index.js
+++ b/site/components/date-bubble/index.js
@@ -27,7 +27,9 @@ function displayDateContent(startDateTime, endDateTime) {
 }
 
 const DateBubble = ({ startDateTime, endDateTime }: DateBubbleProps) => (
-  <div className={styles.dateBubble}>{displayDateContent(startDateTime, endDateTime)}</div>
+  <div itemProp="startDate" content={startDateTime.iso} className={styles.dateBubble}>
+    {displayDateContent(startDateTime, endDateTime)}
+  </div>
 );
 
 export default DateBubble;

--- a/site/components/event-title/index.js
+++ b/site/components/event-title/index.js
@@ -11,7 +11,7 @@ type EventTitleProps = {
 };
 
 const EventTitle = ({ eventLink, eventTitle }: EventTitleProps) => (
-  <h2 className={styles.eventTitle}>
+  <h2 className={styles.eventTitle} itemProp="name">
     <Link to="event" navigationData={eventLink} className={styles.eventTitleLink}>
       <span>{eventTitle}</span>
     </Link>

--- a/site/fetchers/badger-brain.js
+++ b/site/fetchers/badger-brain.js
@@ -126,6 +126,9 @@ const dateTimeFieldsEvents = `
 const fullEventsQuery = `
   ${basicFields}
   ${dateTimeFieldsEvents}
+  location {
+    address
+  }
 `;
 
 export function getData() {

--- a/site/pages/event/index.js
+++ b/site/pages/event/index.js
@@ -44,7 +44,7 @@ export default function Event({ event }: EventProps) {
   };
 
   return (
-    <div className={styles.background}>
+    <div className={styles.background} itemScope itemType="http://schema.org/Event">
       <Social {...social} />
       <Section>
         <Container>
@@ -54,7 +54,9 @@ export default function Event({ event }: EventProps) {
               startDateTime={event.startDateTime}
               endDateTime={setEndDate('today', event.startDateTime, event.endDateTime)}
             />
-            <h1 className={styles.eventTitle}>{event.title}</h1>
+            <h1 className={styles.eventTitle} itemProp="name">
+              {event.title}
+            </h1>
             <div className={styles.twoColumn}>
               <div className={styles.event}>
                 <div className={styles.eventDescription}>{event.strapline}</div>

--- a/site/pages/event/index.js
+++ b/site/pages/event/index.js
@@ -34,6 +34,9 @@ type EventProps = {
     internalLinks: LinkList,
     externalLinks: LinkList,
     featureImageFilename: string,
+    location?: {
+      address: string,
+    },
   },
 };
 
@@ -46,6 +49,7 @@ export default function Event({ event }: EventProps) {
 
   return (
     <div className={styles.background} itemScope itemType="http://schema.org/Event">
+      <span itemProp="location" content={event.location ? event.location.address : ''} />
       <Social {...social} />
       <Section>
         <Container>

--- a/site/pages/event/index.js
+++ b/site/pages/event/index.js
@@ -18,9 +18,10 @@ import { setEndDate } from '../../fetchers/util/events';
 
 type DateShape = {
   date: string,
+  iso?: string,
+  month?: string,
   monthSym: string,
   year: string,
-  month?: string,
 };
 
 type EventProps = {

--- a/site/pages/events/events-list-entry/index.js
+++ b/site/pages/events/events-list-entry/index.js
@@ -50,7 +50,12 @@ const EventsListEntry = ({
   };
 
   return (
-    <li key={`entry_${id}`} className={styles.eventItem}>
+    <li
+      key={`entry_${id}`}
+      className={styles.eventItem}
+      itemScope
+      itemType="http://schema.org/Event"
+    >
       <Grid fit={false}>
         <Cell size={12}>
           <HR color="grey" customClassName={styles.mobileHorizontalLine} />

--- a/site/pages/events/events-list-entry/index.js
+++ b/site/pages/events/events-list-entry/index.js
@@ -27,6 +27,9 @@ type EventsListEntryProps = {
   endDateTime?: DateShape,
   type: 'news' | 'event',
   timeline?: 'past' | 'future' | 'today',
+  location?: {
+    address: string,
+  },
 };
 
 const EventsListEntry = ({
@@ -41,6 +44,7 @@ const EventsListEntry = ({
   internalLinks,
   startDateTime,
   featureImageFilename,
+  location,
 }: EventsListEntryProps) => {
   const eventLink = {
     year: startDateTime.year,
@@ -56,6 +60,7 @@ const EventsListEntry = ({
       itemScope
       itemType="http://schema.org/Event"
     >
+      <span itemProp="location" content={location ? location.address : ''} />
       <Grid fit={false}>
         <Cell size={12}>
           <HR color="grey" customClassName={styles.mobileHorizontalLine} />


### PR DESCRIPTION
#### Description

When web spiders crawl sites they take on account semantic HTML to extract data to help search engines, but sometimes they need more info

To tackle this problem Google, Microsoft, Yahoo and Yandex founded [Schema.org](http://schema.org/) to provide consistent information (microdata) for spiders as HTML attributes

I added microdata to event components  from Schema.org to help SEO on events

#### Can this PR be merged immediately after testing (eg. rebase, infrastructure update)?

Yes

#### Test setup (any additional steps that need to be taken to test the story)

Unfortunately, we cannot test this on local environment, because this need to be exposed to web spiders

At the moment when we google it [`red badger events`](https://www.google.co.uk/search?q=red+badger+events&oq=red+badger+events&) we have the following response

![screen shot 2018-05-31 at 12 14 16](https://user-images.githubusercontent.com/10330222/40784200-df501f6c-64dc-11e8-9a25-40117163818c.png)

This display should improve once this code is released

#### Do we need to add any documentation?

I used this [schema](http://schema.org/Event)

### Here is a GIF
![](https://media.giphy.com/media/G0fqJ3X2erQha/giphy.gif)