### PR TITLE
Array.includes Polyfill for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["flow", "react", "env", "stage-1"]
+  "presets": ["flow", "react", "env", "stage-1"],
+  "plugins": [
+    "array-includes"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.2",
+    "babel-plugin-array-includes": "^2.0.3",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-array-includes@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-array-includes/-/babel-plugin-array-includes-2.0.3.tgz#cf5452e81c7b803fb7959f1045ac88e2ec28ff76"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
IE11 does not support `Array.includes()` and we support that so need to add polyfill for it. For some reason we didn't have it in production :/