### PR TITLE
Link Pride heart on homepage to Pride case study landing page (in Hubspot)

### DIFF
--- a/site/components/pride-heart/style.css
+++ b/site/components/pride-heart/style.css
@@ -14,7 +14,6 @@
   .prideHeart {
     width: 96px;
     margin: 0;
-    position: absolute;
     top: 57px;
     left: 372px;
   }
@@ -24,9 +23,7 @@
   .prideHeart {
     width: 150px;
     vertical-align: bottom;
-    display: inline-block;
-    position: relative;
-    top: 10px;
-    left: -20px;
+    top: 68px;
+    left: 550px;
   }
 }

--- a/site/pages/home/homepage-top-slice/index.js
+++ b/site/pages/home/homepage-top-slice/index.js
@@ -30,10 +30,16 @@ class HomepageTopSlice extends React.Component<{}> {
             onMouseOut={() => this.animatePrideHeart('reverse')}
             onBlur={() => this.animatePrideHeart('reverse')}
             onTouchStart={() => this.animatePrideHeart('forward')}
+            onClick={() => {
+              window.location =
+                'https://lp.red-badger.com/why-react-native-was-the-solution-for-pride-in-londons-2018-app';
+            }}
+            role="link"
+            tabIndex="0"
           >
-            <h1 className={styles.badgerSlogan}>
-              Let’s make<br />things better
-            </h1>
+            <h1 className={styles.badgerSlogan}>Let’s make</h1>
+            <br />
+            <h1 className={styles.badgerSlogan}>things better</h1>
             <PrideHeart play={animatePrideHeart} direction={animationDirection} />
           </div>
           <p className={cx('sloganDescription', 'fadeInUp')}>

--- a/site/pages/home/homepage-top-slice/style.css
+++ b/site/pages/home/homepage-top-slice/style.css
@@ -15,12 +15,19 @@
 
 .sloganWrapper {
   position: relative;
+  margin-bottom: 83px;
+  cursor: pointer;
 }
 
 .badgerSlogan {
   composes: fontXL from '../../../css/typography/_fonts.css';
   composes: serif from '../../../css/typography/_fonts.css';
-  margin-bottom: 85px;
+  display: inline-block;
+  border-bottom: 2px solid badgerWhite;
+}
+
+.sloganWrapper:hover h1 {
+  border-bottom: 2px solid badgerRed;
 }
 
 .lastWord {
@@ -60,17 +67,16 @@
     padding: 50px 100px 100px 120px;
   }
 
-  .badgerSlogan {
+  .sloganWrapper {
     margin-bottom: 30px;
+  }
+
+  .badgerSlogan {
     display: inline-block;
   }
 }
 
 @media largeScreen {
-  .sloganWrapper {
-    position: static;
-  }
-
   .arrow svg {
     height: 20px;
   }


### PR DESCRIPTION

### Changes

#### Trello Ticket / Github Issue Link
https://trello.com/c/MOI3eqQY/261-link-pride-heart-on-homepage-to-pride-case-study-landing-page-in-hubspot
#### Description
ACs:

* Landing page link: 
https://lp.red-badger.com/why-react-native-was-the-solution-for-pride-in-londons-2018-app
* Open in current window
* Mobile interaction to be refined in Dev
* Desktop styling to be refined in Dev
* Event tracking to track clicks to be added
