### PR TITLE
Add gdpr notice to newsletter form

### DIFF
--- a/site/pages/home/newsletter-slice/before-sign-up/index.js
+++ b/site/pages/home/newsletter-slice/before-sign-up/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import classnames from 'classnames/bind';
+
 import styles from '../style.css';
 
 const cx = classnames.bind(styles);
@@ -84,6 +85,12 @@ class BeforeSignUp extends Component<BeforeSignUpProps, BeforeSignUpState> {
             {this.state.submitting ? 'Signing up....' : 'Sign Up'}
           </button>
         </form>
+
+        <p className={styles.gdpr}>
+          Once you are signed up to our newsletter, you can unsubscribe and update your preferences
+          at any time. We’ll share our news, blogs, and invitations to our events and webinars. View
+          our Privacy policy here to find out more about how we take care of your personal data.
+        </p>
 
         <noscript>
           <p className={styles.jsDisabled}>

--- a/site/pages/home/newsletter-slice/before-sign-up/index.js
+++ b/site/pages/home/newsletter-slice/before-sign-up/index.js
@@ -89,7 +89,8 @@ class BeforeSignUp extends Component<BeforeSignUpProps, BeforeSignUpState> {
         <p className={styles.gdpr}>
           Once you are signed up to our newsletter, you can unsubscribe and update your preferences
           at any time. We’ll share our news, blogs, and invitations to our events and webinars. View
-          our Privacy policy here to find out more about how we take care of your personal data.
+          our <a href="https://red-badger.com/privacy-policy">Privacy policy</a> to find out more
+          about how we take care of your personal data.
         </p>
 
         <noscript>

--- a/site/pages/home/newsletter-slice/style.css
+++ b/site/pages/home/newsletter-slice/style.css
@@ -56,7 +56,15 @@
 }
 
 .form > div {
-  padding-bottom: 30px;
+  padding-bottom: 15px;
+}
+
+.gdpr {
+  max-width: 610px;
+  margin: 0 auto 10px;
+  composes: fontXS from '../../../css/typography/_fonts.css';
+  composes: sansSerif from '../../../css/typography/_fonts.css';
+  text-align: left;
 }
 
 .formLabel {
@@ -151,7 +159,7 @@
 
   .submitButton {
     display: inline-block;
-    margin: 0 auto 40px;
+    margin: 0 auto;
     vertical-align: top;
   }
 

--- a/site/pages/home/newsletter-slice/style.css
+++ b/site/pages/home/newsletter-slice/style.css
@@ -67,6 +67,11 @@
   text-align: left;
 }
 
+.gdpr > a {
+  color: inherit;
+  border-bottom: 2px solid;
+}
+
 .formLabel {
   composes: fontS from '../../../css/typography/_fonts.css';
   composes: sansSerif from '../../../css/typography/_fonts.css';


### PR DESCRIPTION
### ⏫  Changes

#### 🎫  Trello Ticket / Github Issue

https://trello.com/c/UBh2SfaN/262-gdpr-add-information-notices-copy-to-newsletter-in-mailchimp-sign-up-process

#### 🗒  Description

Add GDPR text to newsletter sub form.

---

### 💣  Test

#### ☑️  Test plan

Check the styling is as on design https://app.zeplin.io/project/57c8297fc3cf63795b6a4520/screen/5b435b73b3b2bd6e65e95031 and shows correctly on different viewports.
