### PR TITLE
Use label for passing scroll value

### DIFF
--- a/site/components/scroll-tracker/index.js
+++ b/site/components/scroll-tracker/index.js
@@ -20,7 +20,7 @@ class ScrollTracker extends React.Component<{ children: React.Node }> {
     ReactGA.event({
       category: `Page scroll depth`,
       action: 'scroll',
-      value: scrollPercentage,
+      label: '' + scrollPercentage,
     });
     logScrollDepth(scrollPercentage);
   }


### PR DESCRIPTION
Event value is a sum in ga so does not provide the info we want.