### PR TITLE
Enforce node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "website-honestly",
   "version": "1.0.0",
   "description": "Red Badger Website. Honestly.",
+  "engines": {
+    "node": "11.2.0",
+    "npm": "6.4.1"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Red Badger Website. Honestly.",
   "engines": {
-    "node": "11.2.0",
-    "npm": "6.4.1"
+    "node": "6.10.3",
+    "npm": "3.10.10"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
#### Trello Ticket / Github Issue

https://trello.com/c/VL4geWT1/211-enforce-correct-versions-of-node-and-npm-across-the-project

#### Description

Sets the node version in `package.json` to `6.10.3` with a corresponding npm version of `3.10.10`

#### Test

Yarn will fail `Validating package.json` if there is a mismatch in versions.

e.g:

```
error website-honestly@1.0.0: The engine "node" is incompatible with this module. Expected version "6.10.3". Got "11.2.0"
error Found incompatible module
```