### PR TITLE
Lock storybook-deployer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@storybook/addon-notes": "^3.4.8",
     "@storybook/addons": "^3.4.8",
     "@storybook/react": "^3.4.8",
-    "@storybook/storybook-deployer": "^2.3.0",
+    "@storybook/storybook-deployer": "2.4.0",
     "assets-webpack-plugin": "^3.5.1",
     "autoprefixer": "^7.2.3",
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,10 +372,10 @@
     webpack "^3.11.0"
     webpack-hot-middleware "^2.22.1"
 
-"@storybook/storybook-deployer@^2.3.0":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.1.tgz#18018114d58d0c1e584d06b68e57900804469e51"
-  integrity sha512-tXgD7vpX2nRGpMZr4hzZ3J34Xt3h5sbk3HjnNrBM3bMMWYf5/pMfTtlpIzyzA+ljoI77ZjuFOWZfgPaUTxHeJw==
+"@storybook/storybook-deployer@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.4.0.tgz#48573fb0cabb6cc39dcbb7b8063c507f07d78924"
+  integrity sha512-6WMtrT7v61TmJzYSZ1yXXGuNqC45dKP7Z1s5WJFxxThuypCq43jMnjkwqVmG0FB9f9e9tQq4Abaoz+3Jby26nA==
   dependencies:
     git-url-parse "^8.1.0"
     glob "^7.1.3"


### PR DESCRIPTION
Higher versions require a version of node that supports the
splat (...) operator.