### PR TITLE
Ignore gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,9 @@ workflows:
 
   build_and_deploy:
     jobs:
-      - build
+      - build:
+          branches:
+            ignore: gh-pages
 
       - validate_formatting:
           requires:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "make dev",
     "badger": "node dev/badger.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "deploy-storybook": "storybook-to-ghpages -o storybook"
+    "deploy-storybook": "storybook-to-ghpages"
   },
   "dependencies": {
     "@storybook/addon-actions": "^3.4.8",


### PR DESCRIPTION
Ignore gh-pages branch on CircleCi (it does not need to be built, but storybook-deployer pushes to it and so triggers it).