### PR TITLE
Fixes typo on jobs page. "sick pay" rather than "sick page"

### DIFF
--- a/site/pages/join-us/__snapshots__/test.js.snap
+++ b/site/pages/join-us/__snapshots__/test.js.snap
@@ -1157,7 +1157,7 @@ exports[`site/pages/join-us renders correctly 1`] = `
             Object {
               "benefits": Array [
                 Object {
-                  "answer": "As well as enhanced sick page, we also offer private medical cover provided by Vitality.",
+                  "answer": "As well as enhanced sick pay, we also offer private medical cover provided by Vitality.",
                   "mobileView": false,
                   "question": "How does Red Badger support me if I’m unwell?",
                 },
@@ -1299,7 +1299,7 @@ exports[`site/pages/join-us renders correctly 1`] = `
                           benefits={
                             Array [
                               Object {
-                                "answer": "As well as enhanced sick page, we also offer private medical cover provided by Vitality.",
+                                "answer": "As well as enhanced sick pay, we also offer private medical cover provided by Vitality.",
                                 "mobileView": false,
                                 "question": "How does Red Badger support me if I’m unwell?",
                               },
@@ -1343,7 +1343,7 @@ exports[`site/pages/join-us renders correctly 1`] = `
                                 key="How does Red Badger support me if I’m unwell?"
                               >
                                 <Benefit
-                                  answer="As well as enhanced sick page, we also offer private medical cover provided by Vitality."
+                                  answer="As well as enhanced sick pay, we also offer private medical cover provided by Vitality."
                                   mobileView={false}
                                   question="How does Red Badger support me if I’m unwell?"
                                 >
@@ -1377,7 +1377,7 @@ exports[`site/pages/join-us renders correctly 1`] = `
                                       className="benefit__answer__hidden"
                                     >
                                       <p>
-                                        As well as enhanced sick page, we also offer private medical cover provided by Vitality.
+                                        As well as enhanced sick pay, we also offer private medical cover provided by Vitality.
                                       </p>
                                     </div>
                                   </div>

--- a/site/pages/join-us/benefits.js
+++ b/site/pages/join-us/benefits.js
@@ -13,7 +13,7 @@ const benefitsCategories = [
         mobileView: false,
         question: 'How does Red Badger support me if I’m unwell?',
         answer:
-          'As well as enhanced sick page, we also offer private medical cover provided by Vitality.',
+          'As well as enhanced sick pay, we also offer private medical cover provided by Vitality.',
       },
       {
         mobileView: false,


### PR DESCRIPTION
#### Trello Ticket / Github Issue
https://github.com/redbadger/website-honestly/issues/840

#### Description
Fixes a small typo on the jobs page. Should read sick pay rather than sick page