### PR TITLE
adds secure_url property to meta data on case studies

### DIFF
--- a/site/components/social/index.js
+++ b/site/components/social/index.js
@@ -21,6 +21,7 @@ const Social = ({ title, description, metaImage, altText, url }: SocialProps) =>
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: title },
       { property: 'og:image', content: `https://red-badger.com${metaImage}` },
+      { property: 'og:image:secure_url', content: `https://red-badger.com${metaImage}` },
       { property: 'og:image:alt', content: altText },
       { property: 'og:description', content: description },
     ].concat(url ? [{ property: 'og:url', content: url }] : [])}

--- a/site/pages/about-us/__snapshots__/test.js.snap
+++ b/site/pages/about-us/__snapshots__/test.js.snap
@@ -105,6 +105,10 @@ exports[`site/pages/about-us renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "Our founders Dave, Stu and Cain.",
                 "property": "og:image:alt",
               },
@@ -157,6 +161,10 @@ exports[`site/pages/about-us renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "Our founders Dave, Stu and Cain.",
                   "property": "og:image:alt",
                 },
@@ -207,6 +215,10 @@ exports[`site/pages/about-us renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "Our founders Dave, Stu and Cain.",

--- a/site/pages/badger-profile/__snapshots__/test.js.snap
+++ b/site/pages/badger-profile/__snapshots__/test.js.snap
@@ -77,6 +77,10 @@ exports[`site/pages/badger-profile renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "An illustration of different people.",
                 "property": "og:image:alt",
               },
@@ -129,6 +133,10 @@ exports[`site/pages/badger-profile renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "An illustration of different people.",
                   "property": "og:image:alt",
                 },
@@ -179,6 +187,10 @@ exports[`site/pages/badger-profile renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "An illustration of different people.",

--- a/site/pages/cookie-policy/__snapshots__/test.js.snap
+++ b/site/pages/cookie-policy/__snapshots__/test.js.snap
@@ -151,6 +151,10 @@ exports[`site/pages/cookie-policy renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "Red Badger logo",
                 "property": "og:image:alt",
               },
@@ -203,6 +207,10 @@ exports[`site/pages/cookie-policy renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "Red Badger logo",
                   "property": "og:image:alt",
                 },
@@ -253,6 +261,10 @@ exports[`site/pages/cookie-policy renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "Red Badger logo",

--- a/site/pages/join-us/__snapshots__/test.js.snap
+++ b/site/pages/join-us/__snapshots__/test.js.snap
@@ -86,6 +86,10 @@ exports[`site/pages/join-us renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "An illustration an award we won.",
                 "property": "og:image:alt",
               },
@@ -138,6 +142,10 @@ exports[`site/pages/join-us renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "An illustration an award we won.",
                   "property": "og:image:alt",
                 },
@@ -188,6 +196,10 @@ exports[`site/pages/join-us renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "An illustration an award we won.",

--- a/site/pages/privacy-policy/__snapshots__/test.js.snap
+++ b/site/pages/privacy-policy/__snapshots__/test.js.snap
@@ -487,6 +487,10 @@ exports[`site/pages/privacy-policy renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "Red Badger logo",
                 "property": "og:image:alt",
               },
@@ -539,6 +543,10 @@ exports[`site/pages/privacy-policy renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "Red Badger logo",
                   "property": "og:image:alt",
                 },
@@ -589,6 +597,10 @@ exports[`site/pages/privacy-policy renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "Red Badger logo",

--- a/site/pages/technology/__snapshots__/test.js.snap
+++ b/site/pages/technology/__snapshots__/test.js.snap
@@ -72,6 +72,10 @@ exports[`site/pages/technology renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "The sentence \\"We choose the right tech for the job\\".",
                 "property": "og:image:alt",
               },
@@ -124,6 +128,10 @@ exports[`site/pages/technology renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "The sentence \\"We choose the right tech for the job\\".",
                   "property": "og:image:alt",
                 },
@@ -174,6 +182,10 @@ exports[`site/pages/technology renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "The sentence \\"We choose the right tech for the job\\".",

--- a/site/pages/terms-and-conditions/__snapshots__/test.js.snap
+++ b/site/pages/terms-and-conditions/__snapshots__/test.js.snap
@@ -553,6 +553,10 @@ exports[`site/pages/terms-and-conditions renders correctly 1`] = `
                 "property": "og:image",
               },
               Object {
+                "content": "https://red-badger.commeta-image.jpg",
+                "property": "og:image:secure_url",
+              },
+              Object {
                 "content": "Red Badger logo",
                 "property": "og:image:alt",
               },
@@ -605,6 +609,10 @@ exports[`site/pages/terms-and-conditions renders correctly 1`] = `
                   "property": "og:image",
                 },
                 Object {
+                  "content": "https://red-badger.commeta-image.jpg",
+                  "property": "og:image:secure_url",
+                },
+                Object {
                   "content": "Red Badger logo",
                   "property": "og:image:alt",
                 },
@@ -655,6 +663,10 @@ exports[`site/pages/terms-and-conditions renders correctly 1`] = `
                   Object {
                     "content": "https://red-badger.commeta-image.jpg",
                     "property": "og:image",
+                  },
+                  Object {
+                    "content": "https://red-badger.commeta-image.jpg",
+                    "property": "og:image:secure_url",
                   },
                   Object {
                     "content": "Red Badger logo",


### PR DESCRIPTION
A patch to add secure_url property to open graph images served over https