### PR TITLE
Move blocking script to bottom of page

### DIFF
--- a/site/index.pug
+++ b/site/index.pug
@@ -12,7 +12,7 @@ head
     each size in ['96x96', '192x192', '16x16', '32x32', '194x194']
         link(rel='icon' href=`/assets-honestly/favicons/favicon-${size}.png` type='image/png' sizes=size)
     link(rel='manifest' href='/manifest.json')
-    link(rel='stylesheet' type='text/css' href='https://cloud.typography.com/7838134/6842972/css/fonts.css')
+    link(rel='stylesheet' href='https://cloud.typography.com/7838134/6842972/css/fonts.css')
     title #{title}
     if description
         meta(name="description" content=description)
@@ -21,7 +21,7 @@ head
         .
             !{meta}
     if cssPath
-        link(rel="stylesheet" href=cssPath type="text/css" charset="utf-8")
+        link(rel="stylesheet" href=cssPath charset="utf-8")
 
     script.
         /*! loadCSS. [c]2017 Filament Group, Inc. MIT License */
@@ -46,7 +46,7 @@ head
     //- End Facebook Pixel Code
 
     //- Begin LinkedIn Pixel Code
-    script(type='text/javascript').
+    script.
         _linkedin_data_partner_id = "103577";
         (function(){var s = document.getElementsByTagName("script")[0];
         var b = document.createElement("script"); b.type = "text/javascript";b.async = true;
@@ -87,10 +87,10 @@ body
       !{bodyContent}
     input(id="state-hash" type="hidden" value=stateHash || 'none')
     if jsPath
-        script(type="text/javascript" src=jsPath)
+        script(src=jsPath)
 
     //- Start of HubSpot Embed Code
-    script(type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/4210858.js")
+    script(id="hs-script-loader" async defer src="//js.hs-scripts.com/4210858.js")
     //- End of HubSpot Embed Code
 
     style

--- a/site/index.pug
+++ b/site/index.pug
@@ -13,15 +13,6 @@ head
         link(rel='icon' href=`/assets-honestly/favicons/favicon-${size}.png` type='image/png' sizes=size)
     link(rel='manifest' href='/manifest.json')
     link(rel='stylesheet' type='text/css' href='https://cloud.typography.com/7838134/6842972/css/fonts.css')
-    script(src='https://cdnjs.cloudflare.com/ajax/libs/UAParser.js/0.7.17/ua-parser.min.js' charset='utf-8')
-    script(type='text/javascript').
-        var uaSniffer = new UAParser();
-        var browser = uaSniffer.getBrowser();
-        if (window.location.pathname !== '/#{process.env.URL_BASENAME || ''}browser-not-supported/' ) {
-            if (browser.name === 'IE' && browser.major < 10 ) {
-                window.location.pathname = '/#{process.env.URL_BASENAME || ''}browser-not-supported/';
-            }
-        }
     title #{title}
     if description
         meta(name="description" content=description)
@@ -156,3 +147,13 @@ body
                 background-color: #FFD811;
             }
             /* End of HubSpot Cookie Banner CSS overrides */
+
+    script(src='https://cdnjs.cloudflare.com/ajax/libs/UAParser.js/0.7.19/ua-parser.min.js' charset='utf-8' integrity="sha256-/44/B9miLtjvWgFXi6nGKvCzVboFK38jyl5IPsIgS0Y=" crossorigin="anonymous")
+    script.
+        var uaSniffer = new UAParser();
+        var browser = uaSniffer.getBrowser();
+        if (window.location.pathname !== '/#{process.env.URL_BASENAME || ''}browser-not-supported/' ) {
+            if (browser.name === 'IE' && browser.major < 10 ) {
+                window.location.pathname = '/#{process.env.URL_BASENAME || ''}browser-not-supported/';
+            }
+        }


### PR DESCRIPTION
I noticed there is a synchronously loaded script near the top of the html file which is not great for performance. The aim of the script and the one immediately beneath seems to be to redirect the user to https://red-badger.com/browser-not-supported/ if they're using a version if IE older than 10 (i.e. IE8/9), but given that IE9 browser share is [0.2%](https://caniuse.com/usage-table) it seems silly to harm the performance of the vast majority of browsers, so I've moved it to the scripts to bottom of the page.