### PR TITLE
Correct `integrity` attribute for UAParser script

### DIFF
--- a/site/index.pug
+++ b/site/index.pug
@@ -148,7 +148,7 @@ body
             }
             /* End of HubSpot Cookie Banner CSS overrides */
 
-    script(src='https://cdnjs.cloudflare.com/ajax/libs/UAParser.js/0.7.19/ua-parser.min.js' charset='utf-8' integrity="sha256-/44/B9miLtjvWgFXi6nGKvCzVboFK38jyl5IPsIgS0Y=" crossorigin="anonymous")
+    script(src='https://cdnjs.cloudflare.com/ajax/libs/UAParser.js/0.7.19/ua-parser.min.js' integrity='sha256-WfUykOyzFASY5s5n4T1ENGfSfN0YGcvEJ75f1Zv3S0E=' crossorigin='anonymous')
     script.
         var uaSniffer = new UAParser();
         var browser = uaSniffer.getBrowser();


### PR DESCRIPTION
I accidentally included the wrong value for the [`integrity`](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attribute in PR #868 (I had set the minified script to be downloaded but given the integrity hash of the *un*minified version) so the script for checking if the user had an ancient browser was broken. I've corrected this now.

<img width="804" alt="Screenshot 2019-04-05 at 14 32 22" src="https://user-images.githubusercontent.com/5824792/55631305-a9224700-57af-11e9-8ffe-446d8a5b093d.png">