### PR TITLE
Updates workable api url

### DIFF
--- a/site/fetchers/workable/index.js
+++ b/site/fetchers/workable/index.js
@@ -33,6 +33,4 @@ export const getJobs = (key: string) =>
     .then(handleErrors)
     .then(response => response.json())
     .then(response => normalizeJobs(response.jobs))
-    .catch(error => {
-      return error;
-    });
+    .catch(error => error);

--- a/site/fetchers/workable/index.js
+++ b/site/fetchers/workable/index.js
@@ -7,10 +7,10 @@ import sanitizeHtml from 'sanitize-html';
 import handleErrors from '../util/handle-errors';
 
 const jobsUrl =
-  'https://www.workable.com/spi/v3/accounts/redbadger/jobs?include_fields=description,benefits,requirements&state=published';
+  'https://redbadger.workable.com/spi/v3/jobs?include_fields=description,benefits,requirements&state=published';
 
-const normalizeJobs = jobs =>
-  jobs.map(job => ({
+const normalizeJobs = jobs => {
+  return jobs.map(job => ({
     id: job.id,
     title: job.title,
     department: job.department,
@@ -20,9 +20,10 @@ const normalizeJobs = jobs =>
     slug: paramCase(job.title),
     datePosted: job.created_at,
   }));
+};
 
-export const getJobs = (key: string) =>
-  fetch(jobsUrl, {
+export const getJobs = (key: string) => {
+  return fetch(jobsUrl, {
     headers: {
       authorization: `Bearer ${key}`,
       'Content-Type': 'application/json',
@@ -30,6 +31,11 @@ export const getJobs = (key: string) =>
     timeout: 10000,
   })
     .then(handleErrors)
-    .then(response => response.json())
+    .then(response => {
+      return response.json();
+    })
     .then(response => normalizeJobs(response.jobs))
-    .catch(error => error);
+    .catch(error => {
+      return error;
+    });
+};

--- a/site/fetchers/workable/index.js
+++ b/site/fetchers/workable/index.js
@@ -9,8 +9,8 @@ import handleErrors from '../util/handle-errors';
 const jobsUrl =
   'https://redbadger.workable.com/spi/v3/jobs?include_fields=description,benefits,requirements&state=published';
 
-const normalizeJobs = jobs => {
-  return jobs.map(job => ({
+const normalizeJobs = jobs =>
+  jobs.map(job => ({
     id: job.id,
     title: job.title,
     department: job.department,
@@ -20,7 +20,6 @@ const normalizeJobs = jobs => {
     slug: paramCase(job.title),
     datePosted: job.created_at,
   }));
-};
 
 export const getJobs = (key: string) =>
   fetch(jobsUrl, {

--- a/site/fetchers/workable/index.js
+++ b/site/fetchers/workable/index.js
@@ -22,8 +22,8 @@ const normalizeJobs = jobs => {
   }));
 };
 
-export const getJobs = (key: string) => {
-  return fetch(jobsUrl, {
+export const getJobs = (key: string) =>
+  fetch(jobsUrl, {
     headers: {
       authorization: `Bearer ${key}`,
       'Content-Type': 'application/json',
@@ -31,11 +31,8 @@ export const getJobs = (key: string) => {
     timeout: 10000,
   })
     .then(handleErrors)
-    .then(response => {
-      return response.json();
-    })
+    .then(response => response.json())
     .then(response => normalizeJobs(response.jobs))
     .catch(error => {
       return error;
     });
-};

--- a/site/fetchers/workable/test.js
+++ b/site/fetchers/workable/test.js
@@ -4,7 +4,7 @@ import { getJobs } from './index';
 
 describe('site/fetchers/workable', () => {
   it('returns error if request has incorrect access credentials', async () => {
-    nock('https://www.workable.com')
+    nock('https://redbadger.workable.com')
       .get(/.*jobs*/)
       .reply(403, {});
 

--- a/state/test.js
+++ b/state/test.js
@@ -32,7 +32,7 @@ describe('state', () => {
       .get(/.*statuses*/)
       .reply(200, []);
 
-    nock('https://www.workable.com')
+    nock('https://redbadger.workable.com')
       .get(/.*jobs*/)
       .reply(200, { jobs: [] });
 
@@ -84,7 +84,7 @@ describe('state', () => {
       .post(/.*oauth*/)
       .reply(403, {});
 
-    nock('https://www.workable.com')
+    nock('https://redbadger.workable.com')
       .get(/.*jobs*/)
       .reply(500, { jobs: [] });
 


### PR DESCRIPTION
Jobs suddenly vanished from our site, the culprit was an incorrect request url for the workable API. Since there were no changes our end I can only assume that workable either changed the url structure or deprecated the old version.