### PR TITLE
Fix missing box-shadow on footer pseudo-element

### DIFF
--- a/site/components/footer/style.css
+++ b/site/components/footer/style.css
@@ -21,6 +21,10 @@
   box-shadow: -1px -1px linesOnBlack;
 }
 
+.footer:after {
+  box-shadow: 0 -1px linesOnBlack;
+}
+
 .footerContainer {
   max-width: containerMaxWidth;
   width: 100%;


### PR DESCRIPTION
## Trello Ticket / Github Issue

Fixes #889

#### Description

The top edge of the footer was not straight. This was caused by a
missing box-shadow on the :after pseudo-element.

#### Screenshots

<img width="681" alt="Screenshot 2019-11-06 at 15 57 04" src="https://user-images.githubusercontent.com/10130666/68314464-1c759980-00ae-11ea-9c75-b02c901c95b1.png">

#### Test plan

#### Browser testing

##### TIER 1

_Full support. Test all front-end PR's against these._

_WIN10_

- [ ] Chrome
- [ ] Firefox
- [ ] Edge

_Mac High Sierra_

- [ ] Chrome
- [ ] Safari

_iOS: iPhone_

- [ ] Last 2 major iOS versions

_iOS: iPad_

- [ ] Last 2 major iOS versions

_Android_

- [ ] Last 3 major Android versions; check with mixture of devices

##### TIER 2

_Functional support; some visual differences allowed. Only test these if it's mentioned in the test plan._

_WIN 7_

- [ ] IE11
- [ ] Chrome

_Mac Sierra_

- [ ] Safari

_iOS: iPhone_

- [ ] +1 major iOS versions compared to Tier 1

_iOS: iPad_

- [ ] +1 major iOS versions compared to Tier 1

_Ubuntu_

- [ ] Firefox
- [ ] Chromium

### Tracking

### Documentation
