### PR TITLE
Other ways carousel now smooth scrolls for its entire width

### DIFF
--- a/site/pages/experience-us/other-ways/engagement-card/style.css
+++ b/site/pages/experience-us/other-ways/engagement-card/style.css
@@ -15,7 +15,7 @@
 }
 
 .engagementCardContent {
-  padding: 5px 20px;
+  padding: 12px 20px 5px;
 }
 
 .engagementCard:hover .engagementCardCTA {
@@ -49,7 +49,6 @@
 .engagementCardLink {
   composes: serif from '../../../../css/typography/_fonts.css';
   font-size: 16px;
-  line-height: 1.2em;
   display: inline;
   color: badgerBlack;
   position: relative;
@@ -65,7 +64,7 @@
 }
 
 .engagementCardLinkWrapper {
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .engagementCardArrow {

--- a/site/pages/experience-us/other-ways/index.js
+++ b/site/pages/experience-us/other-ways/index.js
@@ -10,9 +10,7 @@ export type OtherWaysProps = {
 };
 
 class OtherWays extends React.Component<OtherWaysProps> {
-  // would use React.Element<'element name here'> but flow is
-  // needlessly obtuse about it. What do you mean classList isn't
-  // available in React.Element?!
+  // would use React.Element<'element name here'> but flow isn't happy about that...
   element: any;
 
   leftButton: any;
@@ -64,10 +62,14 @@ class OtherWays extends React.Component<OtherWaysProps> {
     });
   }
 
-  scrollCarosel(step: number) {
+  scrollCarosel(direction: string) {
     const { element } = this;
     if (element) {
-      (element: any).scrollLeft += step;
+      if (direction === 'forward') {
+        (element: any).scrollLeft += element.offsetWidth - 100;
+      } else {
+        (element: any).scrollLeft -= element.offsetWidth - 100;
+      }
     }
   }
 
@@ -86,7 +88,7 @@ class OtherWays extends React.Component<OtherWaysProps> {
             data-click="carousel-left"
             className={`${styles.carouselButton} ${styles.carouselButtonDisabled}`}
             onClick={() => {
-              this.scrollCarosel(-160);
+              this.scrollCarosel('backwards');
             }}
           >
             <div className={`${styles.button__more} ${styles.button__moreLeft}`}>
@@ -100,7 +102,7 @@ class OtherWays extends React.Component<OtherWaysProps> {
             data-click="carousel-right"
             className={styles.carouselButton}
             onClick={() => {
-              this.scrollCarosel(160);
+              this.scrollCarosel('forward');
             }}
           >
             <div className={`${styles.button__more} ${styles.button__moreRight}`}>

--- a/site/pages/experience-us/other-ways/style.css
+++ b/site/pages/experience-us/other-ways/style.css
@@ -17,6 +17,7 @@
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
+  scroll-behavior: smooth;
   height: 380px;
 }
 

--- a/site/slices/gc-slice/style.css
+++ b/site/slices/gc-slice/style.css
@@ -92,6 +92,10 @@
     padding: 14px 16px;
     width: 292px;
   }
+
+  .goldCoinsHeading {
+    font-size: 60px;
+  }
 }
 
 @media largeScreen {


### PR DESCRIPTION
- See how we work font size bumped to 60px on tablet+desktop
- More padding on the titles for other ways cards
- Reduced line-height for other ways cards
