### PR TITLE
removes second onclick definition

### DIFF
--- a/site/pages/join-us/jobs/jobs-list-entry/index.js
+++ b/site/pages/join-us/jobs/jobs-list-entry/index.js
@@ -55,7 +55,6 @@ class JobsListEntry extends Component<JobProps, JobsListEntryState> {
             <Cell size={12} breakOn="smallScreen">
               <button
                 type="button"
-                onClick={this.handleClick}
                 aria-expanded={open}
                 aria-label={`expand ${title} job description`}
                 className={styles.jobEntry__more}


### PR DESCRIPTION
#### Trello Ticket / Github Issue

#### Description

#### Screenshots

#### Test plan

#### Browser testing

##### TIER 1

_Full support. Test all front-end PR's against these._

_WIN10_

- [ ] Chrome
- [ ] Firefox
- [ ] Edge

_Mac High Sierra_

- [ ] Chrome
- [ ] Safari

_iOS: iPhone_

- [ ] Last 2 major iOS versions

_iOS: iPad_

- [ ] Last 2 major iOS versions

_Android_

- [ ] Last 3 major Android versions; check with mixture of devices

##### TIER 2

_Functional support; some visual differences allowed. Only test these if it's mentioned in the test plan._

_WIN 7_

- [ ] IE11
- [ ] Chrome

_Mac Sierra_

- [ ] Safari

_iOS: iPhone_

- [ ] +1 major iOS versions compared to Tier 1

_iOS: iPad_

- [ ] +1 major iOS versions compared to Tier 1

_Ubuntu_

- [ ] Firefox
- [ ] Chromium

### Tracking

### Documentation
