### PR TITLE
Add publish workflows

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -1,4 +1,4 @@
-name: publish-staging
+name: publish-production
 on:
   workflow_dispatch: {}
 jobs:
@@ -8,7 +8,7 @@ jobs:
       - name: call-publish-API
         uses: indiesdev/curl@v1.1
         with:
-          url: ${{ secrets.PUBLISH_STAGING_URL }}
+          url: ${{ secrets.PUBLISH_PRODUCTION_URL }}
           method: POST
           headers: '{ "Accept": "application/json", "Content-Type": "application/json" }'
           timeout: 15000 # 15 seconds

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           url: ${{ secrets.PUBLISH_STAGING_URL }}
           method: POST
-          headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+          headers: '{ "Accept": "application/json", "Content-Type": "application/json" }'
           timeout: 15000 # 15 seconds

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,7 +1,9 @@
 name: publish-staging
 on:
-  workflow_dispatch:
-    inputs:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - 'publish-action'
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -15,3 +15,4 @@ jobs:
           method: POST
           headers: '{ "Accept": "application/json", "Content-Type": "application/json" }'
           timeout: 15000 # 15 seconds
+          log-response: true

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,13 @@
+name: publish-staging
+on: []
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: call-publish-API
+        uses: indiesdev/curl@v1.1
+        with:
+          url: ${{ secrets.PUBLISH_STAGING_URL }}
+          method: POST
+          headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+          timeout: 15000 # 15 seconds

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,5 +1,7 @@
 name: publish-staging
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,5 +1,5 @@
 name: publish-staging
-on: []
+on: workflow_dispatch
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds github actions to publish new content.

This works by calling the publishing Lambda function in AWS, and can be triggered manually from the Actions tab.